### PR TITLE
disable WalletConnect option on Ganache network

### DIFF
--- a/src/assets/scss/_walletconnect.scss
+++ b/src/assets/scss/_walletconnect.scss
@@ -45,6 +45,11 @@
       margin-left: 1rem;
     }
   }
+
+  &:disabled {
+    cursor: not-allowed;
+    opacity: 0.6;
+  }
 }
 
 .walletconnect__wallet-icon {

--- a/src/components/web3/Web3ModalButton.tsx
+++ b/src/components/web3/Web3ModalButton.tsx
@@ -86,7 +86,11 @@ function ConnectWallet({
                 ? 'walletconnect__options-button--connected'
                 : ''
             }`}
-          onClick={async () => await onConnectTo(provider[0])}>
+          onClick={async () => await onConnectTo(provider[0])}
+          // disable WalletConnect button on Ganache network
+          disabled={
+            chainId === CHAINS.GANACHE && provider[0] === 'walletconnect'
+          }>
           <span className="wallet-name">{provider[1].display.name}</span>
 
           <ProviderSVG providerName={provider[0]} />


### PR DESCRIPTION
We can only use MetaMask with the Ganache network. So we should disable the WalletConnect option when using Ganache.