### PR TITLE
moves usePrepareAndSignVoteData useSignAndSubmitProposal to proposals/hooks

### DIFF
--- a/src/components/proposals/hooks/index.ts
+++ b/src/components/proposals/hooks/index.ts
@@ -1,0 +1,2 @@
+export * from './useSignAndSubmitProposal';
+export * from './usePrepareAndSignVoteData';

--- a/src/components/proposals/hooks/usePrepareAndSignVoteData.ts
+++ b/src/components/proposals/hooks/usePrepareAndSignVoteData.ts
@@ -10,12 +10,12 @@ import {
   SnapshotVoteProposal,
 } from '@openlaw/snapshot-js-erc712';
 
-import {ContractAdapterNames, Web3TxStatus} from '../types';
+import {ContractAdapterNames, Web3TxStatus} from '../../web3/types';
 import {DEFAULT_CHAIN, SNAPSHOT_HUB_API_URL, SPACE} from '../../../config';
-import {getAdapterAddressFromContracts} from '../helpers';
-import {PRIMARY_TYPE_ERC712} from '../config';
+import {getAdapterAddressFromContracts} from '../../web3/helpers';
+import {PRIMARY_TYPE_ERC712} from '../../web3/config';
 import {StoreState} from '../../../util/types';
-import {useWeb3Modal} from './useWeb3Modal';
+import {useWeb3Modal} from '../../web3/hooks/useWeb3Modal';
 
 type PrepareAndSignVoteDataParam = {
   choice: SnapshotMessageVote['choice'];

--- a/src/components/proposals/hooks/usePrepareAndSignVoteData.unit.test.ts
+++ b/src/components/proposals/hooks/usePrepareAndSignVoteData.unit.test.ts
@@ -1,6 +1,6 @@
 import {renderHook, act} from '@testing-library/react-hooks';
 
-import {ContractAdapterNames, Web3TxStatus} from '../types';
+import {ContractAdapterNames, Web3TxStatus} from '../../web3/types';
 import {usePrepareAndSignVoteData} from '.';
 import {VoteChoices} from '@openlaw/snapshot-js-erc712';
 import Wrapper from '../../../test/Wrapper';

--- a/src/components/proposals/hooks/useSignAndSubmitProposal.ts
+++ b/src/components/proposals/hooks/useSignAndSubmitProposal.ts
@@ -20,12 +20,15 @@ import {
   ContractAdapterNames,
   ContractDAOConfigKeys,
   Web3TxStatus,
-} from '../types';
+} from '../../web3/types';
 import {DEFAULT_CHAIN, SNAPSHOT_HUB_API_URL, SPACE} from '../../../config';
-import {getAdapterAddressFromContracts, getDAOConfigEntry} from '../helpers';
-import {PRIMARY_TYPE_ERC712} from '../config';
+import {
+  getAdapterAddressFromContracts,
+  getDAOConfigEntry,
+} from '../../web3/helpers';
+import {PRIMARY_TYPE_ERC712} from '../../web3/config';
 import {StoreState} from '../../../util/types';
-import {useWeb3Modal} from './useWeb3Modal';
+import {useWeb3Modal} from '../../web3/hooks/useWeb3Modal';
 
 type PrepareAndSignProposalDataParam = {
   body: SnapshotProposalData['payload']['body'];

--- a/src/components/proposals/hooks/useSignAndSubmitProposal.unit.test.ts
+++ b/src/components/proposals/hooks/useSignAndSubmitProposal.unit.test.ts
@@ -1,6 +1,6 @@
 import {renderHook, act} from '@testing-library/react-hooks';
 
-import {ContractAdapterNames, Web3TxStatus} from '../types';
+import {ContractAdapterNames, Web3TxStatus} from '../../web3/types';
 import {rest, server} from '../../../test/server';
 import {SNAPSHOT_HUB_API_URL} from '../../../config';
 import {snapshotAPISubmitMessage} from '../../../test/restResponses';

--- a/src/components/web3/hooks/index.ts
+++ b/src/components/web3/hooks/index.ts
@@ -1,5 +1,3 @@
-export * from './useSignAndSubmitProposal';
-export * from './usePrepareAndSignVoteData';
 export * from './useContractSend';
 export * from './useETHGasPrice';
 export * from './useInitContracts';

--- a/src/pages/membership/CreateMembershipProposal.tsx
+++ b/src/pages/membership/CreateMembershipProposal.tsx
@@ -15,8 +15,8 @@ import {
   useContractSend,
   useETHGasPrice,
   useIsDefaultChain,
-  useSignAndSubmitProposal,
 } from '../../components/web3/hooks';
+import {useSignAndSubmitProposal} from '../../components/proposals/hooks';
 import {CHAINS} from '../../config';
 import {ContractAdapterNames, Web3TxStatus} from '../../components/web3/types';
 import {FormFieldErrors} from '../../util/enums';


### PR DESCRIPTION
**Changes**

- Moves `usePrepareAndSignVoteData`, `useSignAndSubmitProposal` hooks in `components/web3` to `components/proposals`