### PR TITLE
Fixes ProposalPeriod and VotingStatus from new Date causing too many re-renders

### DIFF
--- a/src/components/proposals/ProposalPeriod.tsx
+++ b/src/components/proposals/ProposalPeriod.tsx
@@ -1,12 +1,12 @@
 import React, {useCallback, useEffect, useState} from 'react';
 
 type ProposalPeriodProps = {
-  startPeriod: Date;
-  endPeriod: Date;
+  startPeriodMs: number;
+  endPeriodMs: number;
 };
 
 export default function ProposalPeriod(props: ProposalPeriodProps) {
-  const {startPeriod, endPeriod} = props;
+  const {startPeriodMs, endPeriodMs} = props;
 
   /**
    * Variables
@@ -48,23 +48,26 @@ export default function ProposalPeriod(props: ProposalPeriodProps) {
   useEffect(() => {
     const interval = setInterval(() => {
       const currentDate = new Date();
-      if (currentDate < startPeriod) {
+      const startDate = new Date(startPeriodMs);
+      const endDate = new Date(endPeriodMs);
+
+      if (currentDate < startDate) {
         const start = (
           <span>
             <span className="votingstatus">Starts:</span>{' '}
             <span className="votingstatus__timer">
-              {displayCountdownCached(startPeriod, true)}
+              {displayCountdownCached(startDate, true)}
             </span>
           </span>
         );
 
         setProposalPeriod(start);
-      } else if (currentDate < endPeriod) {
+      } else if (currentDate < endDate) {
         const end = (
           <span>
             <span className="votingstatus">Ends:</span>{' '}
             <span className="votingstatus__timer">
-              {displayCountdownCached(endPeriod)}
+              {displayCountdownCached(endDate)}
             </span>
           </span>
         );
@@ -77,14 +80,20 @@ export default function ProposalPeriod(props: ProposalPeriodProps) {
         clearInterval(interval);
       }
     }, 1000);
-    return () => clearInterval(interval);
-  }, [startPeriod, endPeriod, displayCountdownCached]);
+
+    return () => {
+      clearInterval(interval);
+    };
+  }, [startPeriodMs, endPeriodMs, displayCountdownCached]);
 
   /**
    * Functions
    */
 
-  function displayCountdown(countdown: Date, showDaysOnly?: boolean) {
+  function displayCountdown(
+    countdown: Date,
+    showDaysOnly?: boolean
+  ): string | React.ReactNode {
     const {days, hours, minutes, seconds} = getTimeRemaining(countdown);
 
     if (days > 2 && showDaysOnly) {
@@ -105,10 +114,10 @@ export default function ProposalPeriod(props: ProposalPeriodProps) {
         'sec'
       )}`;
     } else {
-      return React.createElement(
-        'span',
-        {className: 'color-brightsalmon'},
-        `${formatTimePeriod(seconds, 'sec')}`
+      return (
+        <span className="color-brightsalmon">
+          {formatTimePeriod(seconds, 'sec')}
+        </span>
       );
     }
   }

--- a/src/components/proposals/VotingStatus.tsx
+++ b/src/components/proposals/VotingStatus.tsx
@@ -78,8 +78,8 @@ export default function VotingStatus({
         {/* CLOCK WHILE IN VOTING */}
         {votingStartEndInitReady && hasVotingStarted && !hasVotingEnded && (
           <ProposalPeriod
-            startPeriod={new Date(votingStartSeconds * 1000)}
-            endPeriod={new Date(votingEndSeconds * 1000)}
+            startPeriodMs={votingStartSeconds * 1000}
+            endPeriodMs={votingEndSeconds * 1000}
           />
         )}
 


### PR DESCRIPTION
**Fixes**

- `ProposalPeriod` timer was mounting and unmounting when using `new Date` as props, as they're always new objects, recreated from the parent's render. This caused the timer never to show.