### PR TITLE
Contract init factory; better error handling for contract init

### DIFF
--- a/src/store/contracts/actions.ts
+++ b/src/store/contracts/actions.ts
@@ -100,7 +100,7 @@ export function initContractOnboarding(
   return initContractThunkFactory({
     actionType: CONTRACT_ONBOARDING,
     adapterNameForRedux: DaoConstants.ONBOARDING,
-    adapterOrExtensionName: ContractAdapterNames.onboarding,
+    adapterOrExtensionName: ContractAdapterNames.ragequit,
     contractAddress,
     lazyImport: () => import('../../truffle-contracts/OnboardingContract.json'),
     web3Instance,
@@ -282,7 +282,10 @@ export function initContractThunkFactory({
         })
       );
     } catch (error) {
-      throw error;
+      // Warn instead of throwing as we want the Dapp to fail gracefully.
+      console.warn(
+        `The contract "${adapterOrExtensionName}" could not be found in the DAO. Are you sure you meant to add this contract's ABI?`
+      );
     }
   };
 }


### PR DESCRIPTION
Fixes #108 
Fixes #107 
Fixes #111 

**Adds**

- Contract init factory function to reduce boilerplate and bugs

**Changes**

- Adds `contractAddress?: string` to init functions if contract address has already been obtained (i.e. using subgraph)

**Fixes**

- Entire app will not fail if a contract (other than `DaoRegistry`) fails to init.