### PR TITLE
Use Moloch v3 branding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# TRIBUTE dao
+# Moloch v3
 
 ## Developer Setup
 
@@ -29,7 +29,7 @@ When you set up your Ganache network workspace in the [Ganache GUI app](https://
 
 Deployments for the development environment are handled automatically with a GitHub Action:
 
-- `GitHub Pages development deployment`: push to `main` branch -> https://openlawteam.github.io/tribute
+- `GitHub Pages development deployment`: push to `main` branch -> https://molochv3.org
 
 ---
 

--- a/public/index.html
+++ b/public/index.html
@@ -24,7 +24,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>TRIBUTE dao</title>
+    <title>Moloch v3</title>
 
     <!-- Start Single Page Apps for GitHub Pages -->
     <script type="text/javascript">

--- a/src/App.unit.test.tsx
+++ b/src/App.unit.test.tsx
@@ -15,7 +15,7 @@ describe('App unit tests', () => {
 
     await waitFor(() => {
       // Header
-      expect(screen.getByText(/TRIBUTE/)).toBeInTheDocument();
+      expect(screen.getByText(/MOLOCH v3/)).toBeInTheDocument();
       // Subtitle
       expect(
         screen.getByText(/for the ongoing development of moloch v3/i)
@@ -45,7 +45,7 @@ describe('App unit tests', () => {
 
     await waitFor(() => {
       // Header
-      expect(screen.getByText(/TRIBUTE/)).toBeInTheDocument();
+      expect(screen.getByText(/MOLOCH v3/)).toBeInTheDocument();
       // Burger icon
       expect(screen.getByLabelText(/menu/i)).toBeInTheDocument();
       expect(

--- a/src/Head.tsx
+++ b/src/Head.tsx
@@ -4,7 +4,7 @@ import {Helmet} from 'react-helmet';
 export default function Head() {
   return (
     <Helmet>
-      <title>TRIBUTE dao</title>
+      <title>MOLOCH v3</title>
       <meta
         name="description"
         content="A modular DAO framework developed and coordinated by its members"

--- a/src/assets/scss/style.scss
+++ b/src/assets/scss/style.scss
@@ -19,7 +19,7 @@
 @use "./membercard"; /* member card styles */
 @use "./memberprofile"; /* member profile styles */
 @use "./landing"; /* landing styles */
-@use "./cube"; /* tribute cube styles */
+@use "./cube"; /* Moloch v3 cube styles */
 
 html {
   height: 100%;

--- a/src/components/logo/Logo.tsx
+++ b/src/components/logo/Logo.tsx
@@ -5,7 +5,7 @@ interface LogoProps {
 export default function Logo(props: LogoProps) {
   return (
     <div className={`logo ${props.size ? `logo--${props.size}` : ''}`}>
-      TRIBUTE
+      MOLOCH v3
     </div>
   );
 }

--- a/src/components/web3/config.ts
+++ b/src/components/web3/config.ts
@@ -2,7 +2,7 @@ import {CoreProposalVoteChoices} from '@openlaw/snapshot-js-erc712';
 import {VoteChoices} from './types';
 
 /**
- * WEB3 CONFIG for TRIBUTE DAO
+ * WEB3 CONFIG for MOLOCH v3
  */
 
 // Vote choices should be "yes", "no" unless Moloch v3 contracts change.

--- a/src/pages/start/GetStarted.tsx
+++ b/src/pages/start/GetStarted.tsx
@@ -8,7 +8,7 @@ import {NavLinks} from '../../components/Nav';
 import FadeIn from '../../components/common/FadeIn';
 import Wrap from '../../components/common/Wrap';
 
-const TributeCube = React.memo(() => {
+const MolochV3Cube = React.memo(() => {
   return (
     <div
       className="cube"
@@ -56,7 +56,7 @@ export default function GetStarted() {
           </div>
 
           <div className="landing__img">
-            <TributeCube />
+            <MolochV3Cube />
           </div>
 
           <div className="landing__button">

--- a/src/test/helpers/defaults.ts
+++ b/src/test/helpers/defaults.ts
@@ -1,6 +1,6 @@
 export const DEFAULT_ETH_ADDRESS: string =
   '0x04028Df0Cea639E97fDD3fC01bA5CC172613211D';
-export const DEFAULT_SPACE: string = 'tributetest';
+export const DEFAULT_SPACE: string = 'molochv3test';
 export const DEFAULT_DAO_REGISTRY_ADDRESS: string =
   process.env.REACT_APP_DAO_REGISTRY_CONTRACT_ADDRESS || '';
 export const DEFAULT_PROPOSAL_HASH: string =

--- a/src/test/restResponses/snapshotAPI.ts
+++ b/src/test/restResponses/snapshotAPI.ts
@@ -23,16 +23,16 @@ export const snapshotAPIRootResponse = {
 
 export const snapshotAPISpaceResponse = {
   token: '0x8f56682a50becb1df2fb8136954f2062871bc7fc',
-  name: 'Tribute',
+  name: 'Moloch v3',
   network: '1',
-  symbol: 'TRIBE',
-  skin: 'tribute',
+  symbol: 'MOLv3',
+  skin: 'molochv3',
   strategies: [
     {
       name: 'moloch',
       params: {
         address: '0x8f56682a50becb1df2fb8136954f2062871bc7fc',
-        symbol: 'TRIBE',
+        symbol: 'MOLv3',
         decimals: 18,
       },
     },


### PR DESCRIPTION
Changes "Tribute" branding to "Moloch v3".

TODO: In `package.json` - `"name"` and `"repository"."url"` need to be updated when this repo is renamed to `molochv3-ui`.