### PR TITLE
Add features to suggest user to add DAO token to wallet

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -9,6 +9,7 @@
       href="%PUBLIC_URL%/apple-touch-icon.png"
     />
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
+    <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico" />
     <link
       rel="icon"
       type="image/png"

--- a/src/assets/scss/_daotoken.scss
+++ b/src/assets/scss/_daotoken.scss
@@ -17,3 +17,41 @@
     width: 20px;
   }
 }
+
+.daotoken__tooltip {
+  position: relative;
+  display: inline-block;
+}
+
+.daotoken__tooltip .daotoken__tooltiptext {
+  visibility: hidden;
+  width: 100px;
+  background-color: #555;
+  color: #fff;
+  text-align: center;
+  border-radius: 6px;
+  padding: 5px;
+  position: absolute;
+  z-index: 1;
+  bottom: 130%;
+  left: 50%;
+  margin-left: -55px;
+  opacity: 0;
+  transition: opacity 0.3s;
+}
+
+.daotoken__tooltip .daotoken__tooltiptext::after {
+  content: "";
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  margin-left: -5px;
+  border-width: 5px;
+  border-style: solid;
+  border-color: #555 transparent transparent transparent;
+}
+
+.daotoken__tooltip:hover .daotoken__tooltiptext {
+  visibility: visible;
+  opacity: 1;
+}

--- a/src/assets/scss/_daotoken.scss
+++ b/src/assets/scss/_daotoken.scss
@@ -1,0 +1,19 @@
+@use "./variables" as *; /* load without namespace for convenience */
+@use "./functions" as *; /* load without namespace for convenience */
+@use "./mixins" as *; /* load without namespace for convenience */
+
+.daotoken__button {
+  padding: 0;
+  outline: none;
+  background: none;
+  border: none;
+  color: inherit;
+  margin-left: 12px;
+  transform: translateY(4px);
+  cursor: pointer;
+
+  svg {
+    height: 20px;
+    width: 20px;
+  }
+}

--- a/src/assets/scss/_redeemcard.scss
+++ b/src/assets/scss/_redeemcard.scss
@@ -46,7 +46,7 @@
   }
 
   @include size-down-down {
-    padding: 0.5rem;
+    padding: 1rem 0.5rem;
     width: 24rem;
     max-width: 100vw;
     box-sizing: border-box;
@@ -78,7 +78,7 @@
   }
 }
 
-.redeemcard__address {
+.redeemcard__address--error {
   background-color: rgba(214, 216, 218, 0.2);
   font-family: $font-mono;
   padding: 0.5rem;

--- a/src/assets/scss/style.scss
+++ b/src/assets/scss/style.scss
@@ -27,6 +27,7 @@
 @use "./footer"; /* footer styles */
 @use "./fireworks"; /* firework styles http://jsfiddle.net/elin/7m3bL/ */
 @use "./redeemcard"; /* redeem card styles */
+@use "./daotoken"; /* DAO token widget styles */
 
 html {
   height: 100%;

--- a/src/assets/svg/CopySVG.tsx
+++ b/src/assets/svg/CopySVG.tsx
@@ -1,0 +1,18 @@
+import {SVGAttributes} from 'react';
+
+export default function CheckSVG(props: SVGAttributes<HTMLOrSVGElement>) {
+  return (
+    <svg
+      aria-hidden="true"
+      focusable="false"
+      data-icon="copy"
+      role="img"
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 448 512"
+      {...props}>
+      <path
+        fill="currentColor"
+        d="M433.941 65.941l-51.882-51.882A48 48 0 0 0 348.118 0H176c-26.51 0-48 21.49-48 48v48H48c-26.51 0-48 21.49-48 48v320c0 26.51 21.49 48 48 48h224c26.51 0 48-21.49 48-48v-48h80c26.51 0 48-21.49 48-48V99.882a48 48 0 0 0-14.059-33.941zM266 464H54a6 6 0 0 1-6-6V150a6 6 0 0 1 6-6h74v224c0 26.51 21.49 48 48 48h96v42a6 6 0 0 1-6 6zm128-96H182a6 6 0 0 1-6-6V54a6 6 0 0 1 6-6h106v88c0 13.255 10.745 24 24 24h88v202a6 6 0 0 1-6 6zm6-256h-64V48h9.632c1.591 0 3.117.632 4.243 1.757l48.368 48.368a6 6 0 0 1 1.757 4.243V112z"></path>
+    </svg>
+  );
+}

--- a/src/assets/svg/WalletSVG.tsx
+++ b/src/assets/svg/WalletSVG.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+export default function ArrowsSVG(props: React.SVGAttributes<SVGElement>) {
+  return (
+    <svg
+      aria-hidden="true"
+      focusable="false"
+      data-icon="wallet"
+      role="img"
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 512 512"
+      {...props}>
+      <path
+        fill="currentColor"
+        d="M461.2 128H80c-8.84 0-16-7.16-16-16s7.16-16 16-16h384c8.84 0 16-7.16 16-16 0-26.51-21.49-48-48-48H64C28.65 32 0 60.65 0 96v320c0 35.35 28.65 64 64 64h397.2c28.02 0 50.8-21.53 50.8-48V176c0-26.47-22.78-48-50.8-48zM416 336c-17.67 0-32-14.33-32-32s14.33-32 32-32 32 14.33 32 32-14.33 32-32 32z"></path>
+    </svg>
+  );
+}

--- a/src/components/dao-token/DaoToken.tsx
+++ b/src/components/dao-token/DaoToken.tsx
@@ -36,12 +36,20 @@ export default function DaoToken({erc20Details}: DaoTokenProps): JSX.Element {
 
   function copyAddressToClipboard() {
     if (!erc20Details) return;
-    const input = document.createElement('input');
-    document.body.appendChild(input);
-    input.setAttribute('value', erc20Details.address);
-    input.select();
+    const copyText = document.createElement('input');
+    document.body.appendChild(copyText);
+    copyText.setAttribute('value', erc20Details.address);
+    copyText.select();
     document.execCommand('copy');
-    document.body.removeChild(input);
+    document.body.removeChild(copyText);
+
+    const tooltip = document.getElementById('copyTooltip');
+    (tooltip as HTMLElement).innerHTML = 'copied!';
+  }
+
+  function resetCopyTooltip() {
+    const tooltip = document.getElementById('copyTooltip');
+    (tooltip as HTMLElement).innerHTML = 'copy address';
   }
 
   /**
@@ -52,18 +60,23 @@ export default function DaoToken({erc20Details}: DaoTokenProps): JSX.Element {
     return (
       <div>
         Token: <span>{truncateEthAddress(erc20Details.address, 7)}</span>
-        <button
-          className="daotoken__button"
-          title="copy address"
-          onClick={copyAddressToClipboard}>
-          <CopySVG />
-        </button>
-        <button
-          className="daotoken__button"
-          title="add to wallet"
-          onClick={addTokenToWallet}>
-          <WalletSVG />
-        </button>
+        <div className="daotoken__tooltip">
+          <button
+            className="daotoken__button"
+            onClick={copyAddressToClipboard}
+            onMouseLeave={resetCopyTooltip}>
+            <span className="daotoken__tooltiptext" id="copyTooltip">
+              copy address
+            </span>
+            <CopySVG />
+          </button>
+        </div>
+        <div className="daotoken__tooltip">
+          <button className="daotoken__button" onClick={addTokenToWallet}>
+            <span className="daotoken__tooltiptext">add to wallet</span>
+            <WalletSVG />
+          </button>
+        </div>
       </div>
     );
   }

--- a/src/components/dao-token/DaoToken.tsx
+++ b/src/components/dao-token/DaoToken.tsx
@@ -1,0 +1,72 @@
+import {truncateEthAddress} from '../../util/helpers/truncateEthAddress';
+import CopySVG from '../../assets/svg/CopySVG';
+import WalletSVG from '../../assets/svg/WalletSVG';
+
+export type ERC20RegisterDetails = {
+  address: string;
+  symbol: string;
+  decimals: number;
+  image: string;
+};
+
+type DaoTokenProps = {
+  erc20Details?: ERC20RegisterDetails;
+};
+
+export default function DaoToken({erc20Details}: DaoTokenProps): JSX.Element {
+  /**
+   * Functions
+   */
+
+  async function addTokenToWallet() {
+    if (!erc20Details) return;
+
+    try {
+      await window.ethereum.request({
+        method: 'wallet_watchAsset',
+        params: {
+          type: 'ERC20',
+          options: erc20Details,
+        },
+      });
+    } catch (error) {
+      console.log(error);
+    }
+  }
+
+  function copyAddressToClipboard() {
+    if (!erc20Details) return;
+    const input = document.createElement('input');
+    document.body.appendChild(input);
+    input.setAttribute('value', erc20Details.address);
+    input.select();
+    document.execCommand('copy');
+    document.body.removeChild(input);
+  }
+
+  /**
+   * Render
+   */
+
+  if (erc20Details) {
+    return (
+      <div>
+        Token: <span>{truncateEthAddress(erc20Details.address, 7)}</span>
+        <button
+          className="daotoken__button"
+          title="copy address"
+          onClick={copyAddressToClipboard}>
+          <CopySVG />
+        </button>
+        <button
+          className="daotoken__button"
+          title="add to wallet"
+          onClick={addTokenToWallet}>
+          <WalletSVG />
+        </button>
+      </div>
+    );
+  }
+
+  return <></>;
+}

--- a/src/components/proposals/ProcessActionTribute.tsx
+++ b/src/components/proposals/ProcessActionTribute.tsx
@@ -14,6 +14,7 @@ import ErrorMessageWithDetails from '../common/ErrorMessageWithDetails';
 import EtherscanURL from '../web3/EtherscanURL';
 import FadeIn from '../common/FadeIn';
 import Loader from '../feedback/Loader';
+import {ERC20RegisterDetails} from '../dao-token/DaoToken';
 
 type ProcessArguments = [
   string, // `dao`
@@ -82,6 +83,15 @@ export default function ProcessActionTribute(props: ProcessActionTributeProps) {
   const daoRegistryAddress = useSelector(
     (s: StoreState) => s.contracts.DaoRegistryContract?.contractAddress
   );
+  const ERC20ExtensionContract = useSelector(
+    (state: StoreState) => state.contracts?.ERC20ExtensionContract
+  );
+
+  /**
+   * State
+   */
+
+  const [erc20Details, setERC20Details] = useState<ERC20RegisterDetails>();
 
   /**
    * Our hooks
@@ -125,6 +135,9 @@ export default function ProcessActionTribute(props: ProcessActionTributeProps) {
     getTributeProposalDetails,
     [TributeContract, daoRegistryAddress, snapshotProposal]
   );
+  const getERC20DetailsCached = useCallback(getERC20Details, [
+    ERC20ExtensionContract,
+  ]);
 
   /**
    * Effects
@@ -161,6 +174,24 @@ export default function ProcessActionTribute(props: ProcessActionTributeProps) {
     // 2. Set reasons
     setOtherDisabledReasons(Object.values(actionDisabledReasonsRef.current));
   }, [account, setOtherDisabledReasons, snapshotProposal]);
+
+  // Prepare DAO token info if original proposer is processing proposal
+  useEffect(() => {
+    // Proposals of this type will have this value stored in its snapshot
+    // metadata.
+    const {accountAuthorizedToProcessPassedProposal} = (
+      snapshotProposal as SnapshotProposal
+    ).msg.payload.metadata;
+
+    if (accountAuthorizedToProcessPassedProposal && account) {
+      if (
+        accountAuthorizedToProcessPassedProposal.toLowerCase() ===
+        account.toLowerCase()
+      ) {
+        getERC20DetailsCached();
+      }
+    }
+  }, [account, getERC20DetailsCached, snapshotProposal]);
 
   /**
    * Functions
@@ -280,8 +311,50 @@ export default function ProcessActionTribute(props: ProcessActionTributeProps) {
         processArguments,
         txArguments
       );
+
+      await addTokenToWallet();
     } catch (error) {
       setSubmitError(error);
+    }
+  }
+
+  async function addTokenToWallet() {
+    if (!erc20Details) return;
+
+    try {
+      await window.ethereum.request({
+        method: 'wallet_watchAsset',
+        params: {
+          type: 'ERC20',
+          options: erc20Details,
+        },
+      });
+    } catch (error) {
+      console.log(error);
+    }
+  }
+
+  async function getERC20Details() {
+    if (!ERC20ExtensionContract) return;
+
+    try {
+      const address = ERC20ExtensionContract.contractAddress;
+      const symbol = await ERC20ExtensionContract.instance.methods
+        .symbol()
+        .call();
+      const decimals = await ERC20ExtensionContract.instance.methods
+        .decimals()
+        .call();
+      const image = `${window.location.origin}/favicon.ico`;
+      setERC20Details({
+        address,
+        symbol,
+        decimals: Number(decimals),
+        image,
+      });
+    } catch (error) {
+      console.log(error);
+      setERC20Details(undefined);
     }
   }
 

--- a/src/hooks/useRedeemCoupon.ts
+++ b/src/hooks/useRedeemCoupon.ts
@@ -67,6 +67,10 @@ export function useRedeemCoupon(): ReturnUseRedeemCoupon {
     submitStatus === FetchStatus.FULFILLED;
 
   /**
+   * Effects
+   */
+
+  /**
    * Functions
    */
 

--- a/src/pages/redeem/Redeem.tsx
+++ b/src/pages/redeem/Redeem.tsx
@@ -158,7 +158,7 @@ export default function RedeemCoupon() {
       <RenderWrapper>
         <div className="form__description--unauthorized">
           <p className="color-brightsalmon">
-            Connect your wallet to redeem coupon.
+            Connect your wallet to view coupon.
           </p>
         </div>
       </RenderWrapper>

--- a/src/pages/redeem/Redeem.tsx
+++ b/src/pages/redeem/Redeem.tsx
@@ -1,14 +1,18 @@
-import {useLocation} from 'react-router-dom';
 import {useCallback, useEffect, useState} from 'react';
+import {useLocation} from 'react-router-dom';
+import {useSelector} from 'react-redux';
 import {toChecksumAddress} from 'web3-utils';
 
+import {StoreState} from '../../store/types';
 import Wrap from '../../components/common/Wrap';
 import FadeIn from '../../components/common/FadeIn';
 import LoaderWithEmoji from '../../components/feedback/LoaderWithEmoji';
+import {ERC20RegisterDetails} from '../../components/dao-token/DaoToken';
 import RedeemManager from './RedeemManager';
 import {useWeb3Modal} from '../../components/web3/hooks';
 import {COUPON_API_URL} from '../../config';
 import {truncateEthAddress} from '../../util/helpers/truncateEthAddress';
+import {AsyncStatus} from '../../util/types';
 
 type RedeemCouponType = {
   amount: number;
@@ -20,17 +24,60 @@ type RedeemCouponType = {
 };
 
 export default function RedeemCoupon() {
+  /**
+   * Selectors
+   */
+
+  const ERC20ExtensionContract = useSelector(
+    (state: StoreState) => state.contracts?.ERC20ExtensionContract
+  );
+
+  /**
+   * State
+   */
+
   const [redeemableCoupon, setReedemableCoupon] = useState<RedeemCouponType[]>(
     []
   );
-  const [isInProcess, setIsInProcess] = useState<boolean>(false);
+  const [couponStatus, setCouponStatus] = useState<AsyncStatus>(
+    AsyncStatus.STANDBY
+  );
+  const [erc20Details, setERC20Details] = useState<ERC20RegisterDetails>();
+  const [erc20DetailsStatus, setERC20DetailsStatus] = useState<AsyncStatus>(
+    AsyncStatus.STANDBY
+  );
 
-  const location = useLocation<{coupon: string}>();
-  const coupon = new URLSearchParams(location.search).get('coupon');
+  /**
+   * Our hooks
+   */
 
   const {connected, account} = useWeb3Modal();
 
+  /**
+   * Their hooks
+   */
+
+  const location = useLocation<{coupon: string}>();
+
+  /**
+   * Variables
+   */
+
+  const coupon = new URLSearchParams(location.search).get('coupon');
+  const isInProcess =
+    couponStatus === AsyncStatus.STANDBY ||
+    couponStatus === AsyncStatus.PENDING ||
+    erc20DetailsStatus === AsyncStatus.STANDBY ||
+    erc20DetailsStatus === AsyncStatus.PENDING;
+
+  /**
+   * Cached callbacks
+   */
+
   const checkBySigOrAddrCached = useCallback(checkBySigOrAddr, [coupon]);
+  const getERC20DetailsCached = useCallback(getERC20Details, [
+    ERC20ExtensionContract,
+  ]);
 
   /**
    * Effects
@@ -42,6 +89,10 @@ export default function RedeemCoupon() {
     }
   }, [account, connected, checkBySigOrAddrCached]);
 
+  useEffect(() => {
+    getERC20DetailsCached();
+  }, [getERC20DetailsCached]);
+
   /**
    * Functions
    */
@@ -49,7 +100,7 @@ export default function RedeemCoupon() {
   // check using signature or eth addr
   async function checkBySigOrAddr() {
     try {
-      setIsInProcess(true);
+      setCouponStatus(AsyncStatus.PENDING);
       // handle adding new authorized user to thee `auth` tbl
       const response = await fetch(`${COUPON_API_URL}/api/coupon/redeem`, {
         method: 'POST',
@@ -64,9 +115,36 @@ export default function RedeemCoupon() {
       const coupons = await response.json();
 
       setReedemableCoupon(coupons);
-      setIsInProcess(false);
+      setCouponStatus(AsyncStatus.FULFILLED);
     } catch (error) {
-      setIsInProcess(false);
+      setCouponStatus(AsyncStatus.REJECTED);
+    }
+  }
+
+  async function getERC20Details() {
+    if (!ERC20ExtensionContract) return;
+
+    try {
+      setERC20DetailsStatus(AsyncStatus.PENDING);
+      const address = ERC20ExtensionContract.contractAddress;
+      const symbol = await ERC20ExtensionContract.instance.methods
+        .symbol()
+        .call();
+      const decimals = await ERC20ExtensionContract.instance.methods
+        .decimals()
+        .call();
+      const image = `${window.location.origin}/favicon.ico`;
+      setERC20Details({
+        address,
+        symbol,
+        decimals: Number(decimals),
+        image,
+      });
+      setERC20DetailsStatus(AsyncStatus.FULFILLED);
+    } catch (error) {
+      console.log(error);
+      setERC20Details(undefined);
+      setERC20DetailsStatus(AsyncStatus.REJECTED);
     }
   }
 
@@ -115,7 +193,7 @@ export default function RedeemCoupon() {
           {redeemableCoupon[0]?.recipient ? (
             <>
               Connect with{' '}
-              <span className="redeemcard__address">
+              <span className="redeemcard__address--error">
                 {truncateEthAddress(
                   toChecksumAddress(redeemableCoupon[0].recipient),
                   7
@@ -133,7 +211,10 @@ export default function RedeemCoupon() {
 
   return (
     <RenderWrapper>
-      <RedeemManager redeemables={redeemableCoupon} />
+      <RedeemManager
+        redeemables={redeemableCoupon}
+        erc20Details={erc20Details}
+      />
     </RenderWrapper>
   );
 }

--- a/src/pages/redeem/RedeemManager.tsx
+++ b/src/pages/redeem/RedeemManager.tsx
@@ -149,7 +149,7 @@ function RedeemCard({redeemable, erc20Details}: RedeemCardProps) {
       </button>
 
       {/* SUBMIT STATUS */}
-      {isInProcessOrDone && (
+      {isInProcessOrDone && !redeemable.isRedeemd && (
         <div
           className="form__submit-status-container"
           style={{marginTop: '1rem'}}>

--- a/src/pages/redeem/RedeemManager.tsx
+++ b/src/pages/redeem/RedeemManager.tsx
@@ -1,26 +1,31 @@
-import {useState, useEffect} from 'react';
-import {useSelector} from 'react-redux';
-import {toChecksumAddress} from 'web3-utils';
-
-import {StoreState} from '../../store/types';
 import {CycleEllipsis} from '../../components/feedback/CycleEllipsis';
 import CycleMessage from '../../components/feedback/CycleMessage';
 import EtherscanURL from '../../components/web3/EtherscanURL';
 import ErrorMessageWithDetails from '../../components/common/ErrorMessageWithDetails';
 import FadeIn from '../../components/common/FadeIn';
 import Loader from '../../components/feedback/Loader';
+import DaoToken, {
+  ERC20RegisterDetails,
+} from '../../components/dao-token/DaoToken';
 import {useRedeemCoupon, FetchStatus} from '../../hooks/useRedeemCoupon';
 import {formatNumber} from '../../util/helpers/formatNumber';
 import {Web3TxStatus} from '../../components/web3/types';
-import {truncateEthAddress} from '../../util/helpers/truncateEthAddress';
-// import {truncateSignature} from '../../util/helpers/truncateSignature';
 import {TX_CYCLE_MESSAGES} from '../../components/web3/config';
 
 type RedeemManagerProps = {
   redeemables: Record<string, any>;
+  erc20Details?: ERC20RegisterDetails;
 };
 
-export default function RedeemManager({redeemables}: RedeemManagerProps) {
+type RedeemCardProps = {
+  redeemable: Record<string, any>;
+  erc20Details?: ERC20RegisterDetails;
+};
+
+export default function RedeemManager({
+  redeemables,
+  erc20Details,
+}: RedeemManagerProps) {
   /**
    *  RENDER
    */
@@ -28,20 +33,12 @@ export default function RedeemManager({redeemables}: RedeemManagerProps) {
   // show the redeem card, if only one coupon available
   return (
     <RenderWrapper>
-      <RedeemCard redeemable={redeemables[0]} />
+      <RedeemCard redeemable={redeemables[0]} erc20Details={erc20Details} />
     </RenderWrapper>
   );
 }
 
-function RedeemCard({redeemable}: Record<string, any>) {
-  /**
-   * Selectors
-   */
-
-  const ERC20ExtensionContract = useSelector(
-    (state: StoreState) => state.contracts?.ERC20ExtensionContract
-  );
-
+function RedeemCard({redeemable, erc20Details}: RedeemCardProps) {
   /**
    * Our hooks
    */
@@ -54,35 +51,6 @@ function RedeemCard({redeemable}: Record<string, any>) {
     txEtherscanURL,
     txIsPromptOpen,
   } = useRedeemCoupon();
-
-  /**
-   * State
-   */
-
-  const [unitType, setUnitType] = useState<string>('tokens');
-
-  /**
-   * Effects
-   */
-
-  useEffect(() => {
-    async function getUnitType() {
-      if (!ERC20ExtensionContract) return;
-
-      try {
-        const symbol = await ERC20ExtensionContract.instance.methods
-          .symbol()
-          .call();
-
-        setUnitType(symbol);
-      } catch (error) {
-        console.log(error);
-        setUnitType('tokens');
-      }
-    }
-
-    getUnitType();
-  }, [ERC20ExtensionContract]);
 
   /**
    * Variables
@@ -149,15 +117,14 @@ function RedeemCard({redeemable}: Record<string, any>) {
       className={`redeemcard redeemcard__content ${
         isDone ? 'fireworks' : ''
       } `}>
-      <p>{truncateEthAddress(toChecksumAddress(redeemable.recipient), 7)}</p>
-      {/* @note Commenting the signature out for now. It may not be useful (and potentially confusing) to the user who doesn't necessarily need to understand what it is. */}
-      {/* <p>{truncateSignature(redeemable.signature, 16)}</p> */}
       <p className="redeemcard__unit">
         {formatNumber(redeemable.amount)}
         <sup>
-          <small>{unitType}</small>
+          <small>{erc20Details?.symbol || 'tokens'}</small>
         </sup>
       </p>
+
+      <DaoToken erc20Details={erc20Details} />
 
       {isDone && (
         <p className="redeemcard__redeemed">
@@ -173,6 +140,7 @@ function RedeemCard({redeemable}: Record<string, any>) {
 
       <button
         className="button"
+        style={{marginTop: '1.5rem'}}
         onClick={async () => {
           await redeemCoupon(redeemable);
         }}


### PR DESCRIPTION
Fixes #338 (implements `wallet_watchAsset` method in example code here https://docs.metamask.io/guide/registering-your-token.html#example to suggest adding DAO token to user's wallet)

🥳 **Adds**

 - new widget on coupon redeem page that allows user to copy DAO token address and add token to wallet
 - triggers automatic suggestion to add DAO token to wallet when user processes a Membership proposal or Tribute proposal

