### PR TITLE
adds configurable `pollInterval` for `useProposalWithOffchainVoteStatus`

### DIFF
--- a/src/components/proposals/hooks/useProposalWithOffchainVoteStatus.ts
+++ b/src/components/proposals/hooks/useProposalWithOffchainVoteStatus.ts
@@ -9,6 +9,7 @@ import {
   OffchainVotingAdapterVotes,
 } from '../types';
 import {BURN_ADDRESS} from '../../../util/constants';
+import {ENVIRONMENT} from '../../../config';
 import {multicall, MulticallTuple} from '../../web3/helpers';
 import {normalizeString} from '../../../util/helpers';
 import {proposalHasFlag} from '../helpers';
@@ -16,7 +17,6 @@ import {StoreState} from '../../../store/types';
 import {useVotingTimeStartEnd} from '.';
 import {useWeb3Modal} from '../../web3/hooks';
 import {VotingState} from '../voting/types';
-import {ENVIRONMENT} from '../../../config';
 
 // @todo Logic to fall back to on-chain polling this if subgraph is not available
 

--- a/src/components/proposals/hooks/useProposalWithOffchainVoteStatus.ts
+++ b/src/components/proposals/hooks/useProposalWithOffchainVoteStatus.ts
@@ -16,6 +16,7 @@ import {StoreState} from '../../../store/types';
 import {useVotingTimeStartEnd} from '.';
 import {useWeb3Modal} from '../../web3/hooks';
 import {VotingState} from '../voting/types';
+import {ENVIRONMENT} from '../../../config';
 
 // @todo Logic to fall back to on-chain polling this if subgraph is not available
 
@@ -30,14 +31,17 @@ type UseProposalWithOffchainVoteStatusReturn = {
   status: ProposalFlowStatus | undefined;
 };
 
-const POLL_INTERVAL_MS: number = 5000;
+const DEFAULT_POLL_INTERVAL_MS: number =
+  ENVIRONMENT === 'production' ? 15000 : 5000;
 
 export function useProposalWithOffchainVoteStatus(
-  proposal: ProposalData
+  proposal: ProposalData,
+  options?: {pollInterval?: number}
 ): UseProposalWithOffchainVoteStatusReturn {
   const {daoProposalVotingAdapter, snapshotDraft, snapshotProposal} = proposal;
   const {votes: snapshotVotes} = snapshotProposal || {};
   const proposalId = snapshotDraft?.idInDAO || snapshotProposal?.idInDAO;
+  const {pollInterval = DEFAULT_POLL_INTERVAL_MS} = options || {};
 
   /**
    * Selectors
@@ -124,7 +128,7 @@ export function useProposalWithOffchainVoteStatus(
    * Cached callbacks
    */
 
-  const pollStatusFromContractCached = useCallback(pollStatusFromContract, [
+  const getStatusFromContractCached = useCallback(getStatusFromContract, [
     daoProposalVotingAdapter,
     daoRegistryABI,
     daoRegistryAddress,
@@ -136,10 +140,10 @@ export function useProposalWithOffchainVoteStatus(
 
   useEffect(() => {
     // Call as soon as possible.
-    pollStatusFromContractCached().catch((error) => {
+    getStatusFromContractCached().catch((error) => {
       setProposalFlowStatusError(error);
     });
-  }, [pollStatusFromContractCached]);
+  }, [getStatusFromContractCached]);
 
   useEffect(() => {
     /**
@@ -162,17 +166,17 @@ export function useProposalWithOffchainVoteStatus(
           clearInterval(pollingIntervalIdRef.current);
         }
 
-        await pollStatusFromContractCached();
+        await getStatusFromContractCached();
       } catch (error) {
         pollingIntervalIdRef.current &&
           clearInterval(pollingIntervalIdRef.current);
 
         setProposalFlowStatusError(error);
       }
-    }, POLL_INTERVAL_MS);
+    }, pollInterval);
 
     pollingIntervalIdRef.current = intervalId;
-  }, [atProcessedInDAO, pollStatusFromContractCached]);
+  }, [atProcessedInDAO, pollInterval, getStatusFromContractCached]);
 
   // Stop polling if propsal is processed
   useEffect(() => {
@@ -203,7 +207,7 @@ export function useProposalWithOffchainVoteStatus(
     };
   }
 
-  async function pollStatusFromContract() {
+  async function getStatusFromContract() {
     try {
       if (!daoRegistryABI || !daoRegistryAddress || !proposalId) {
         return;

--- a/src/components/proposals/hooks/useProposalWithOffchainVoteStatus.unit.test.ts
+++ b/src/components/proposals/hooks/useProposalWithOffchainVoteStatus.unit.test.ts
@@ -1050,6 +1050,13 @@ describe('useProposalWithOffchainVoteStatus unit tests', () => {
 
   // @note This test uses adjusted timeouts
   test('should poll for data when proposal is not yet processed', async () => {
+    // Use cached options to prevent any re-renders
+    const useProposalWithOffchainVoteStatusOptions: Parameters<
+      typeof useProposalWithOffchainVoteStatus
+    >[1] = {
+      pollInterval: 2000,
+    };
+
     const proposalData: Partial<ProposalData> = {
       daoProposalVotingAdapter: {
         votingAdapterAddress: DEFAULT_ETH_ADDRESS,
@@ -1078,9 +1085,10 @@ describe('useProposalWithOffchainVoteStatus unit tests', () => {
       const {result, waitForValueToChange} = await renderHook(
         // Set the `pollInterval` to be a bit quicker
         () =>
-          useProposalWithOffchainVoteStatus(proposalData as ProposalData, {
-            pollInterval: 2000,
-          }),
+          useProposalWithOffchainVoteStatus(
+            proposalData as ProposalData,
+            useProposalWithOffchainVoteStatusOptions
+          ),
         {
           wrapper: Wrapper,
           initialProps: {
@@ -1205,6 +1213,13 @@ describe('useProposalWithOffchainVoteStatus unit tests', () => {
 
   // @note This test uses adjusted timeouts
   test('should stop polling for data when proposal processed', async () => {
+    // Use cached options to prevent any re-renders
+    const useProposalWithOffchainVoteStatusOptions: Parameters<
+      typeof useProposalWithOffchainVoteStatus
+    >[1] = {
+      pollInterval: 2000,
+    };
+
     const proposalData: Partial<ProposalData> = {
       daoProposalVotingAdapter: {
         votingAdapterAddress: DEFAULT_ETH_ADDRESS,
@@ -1232,9 +1247,10 @@ describe('useProposalWithOffchainVoteStatus unit tests', () => {
     const {result} = renderHook(
       // Set the `pollInterval` to be a bit quicker
       () =>
-        useProposalWithOffchainVoteStatus(proposalData as ProposalData, {
-          pollInterval: 2000,
-        }),
+        useProposalWithOffchainVoteStatus(
+          proposalData as ProposalData,
+          useProposalWithOffchainVoteStatusOptions
+        ),
       {
         wrapper: Wrapper,
         initialProps: {
@@ -1303,6 +1319,13 @@ describe('useProposalWithOffchainVoteStatus unit tests', () => {
   }, 6000);
 
   test('should return error when async call throws on initial fetch', async () => {
+    // Use cached options to prevent any re-renders
+    const useProposalWithOffchainVoteStatusOptions: Parameters<
+      typeof useProposalWithOffchainVoteStatus
+    >[1] = {
+      pollInterval: 2000,
+    };
+
     const proposalData: Partial<ProposalData> = {
       daoProposalVotingAdapter: undefined,
       snapshotDraft: fakeSnapshotDraft,
@@ -1314,9 +1337,10 @@ describe('useProposalWithOffchainVoteStatus unit tests', () => {
     const {result, waitForValueToChange} = renderHook(
       // Set the `pollInterval` to be a bit quicker
       () =>
-        useProposalWithOffchainVoteStatus(proposalData as ProposalData, {
-          pollInterval: 1000,
-        }),
+        useProposalWithOffchainVoteStatus(
+          proposalData as ProposalData,
+          useProposalWithOffchainVoteStatusOptions
+        ),
       {
         wrapper: Wrapper,
         initialProps: {
@@ -1378,6 +1402,13 @@ describe('useProposalWithOffchainVoteStatus unit tests', () => {
 
   // @note This test uses adjusted timeouts
   test('should return error when async call throws during polling', async () => {
+    // Use cached options to prevent any re-renders
+    const useProposalWithOffchainVoteStatusOptions: Parameters<
+      typeof useProposalWithOffchainVoteStatus
+    >[1] = {
+      pollInterval: 2000,
+    };
+
     const proposalData: Partial<ProposalData> = {
       daoProposalVotingAdapter: {
         votingAdapterAddress: DEFAULT_ETH_ADDRESS,
@@ -1406,9 +1437,10 @@ describe('useProposalWithOffchainVoteStatus unit tests', () => {
       const {result, waitForValueToChange} = await renderHook(
         // Set the `pollInterval` to be a bit quicker
         () =>
-          useProposalWithOffchainVoteStatus(proposalData as ProposalData, {
-            pollInterval: 2000,
-          }),
+          useProposalWithOffchainVoteStatus(
+            proposalData as ProposalData,
+            useProposalWithOffchainVoteStatusOptions
+          ),
         {
           wrapper: Wrapper,
           initialProps: {

--- a/src/components/proposals/hooks/useProposalWithOffchainVoteStatus.unit.test.ts
+++ b/src/components/proposals/hooks/useProposalWithOffchainVoteStatus.unit.test.ts
@@ -1048,8 +1048,8 @@ describe('useProposalWithOffchainVoteStatus unit tests', () => {
     });
   });
 
-  // @note This test uses higher timeouts
-  test('should poll for data when proposal is not processed', async () => {
+  // @note This test uses adjusted timeouts
+  test('should poll for data when proposal is not yet processed', async () => {
     const proposalData: Partial<ProposalData> = {
       daoProposalVotingAdapter: {
         votingAdapterAddress: DEFAULT_ETH_ADDRESS,
@@ -1076,7 +1076,11 @@ describe('useProposalWithOffchainVoteStatus unit tests', () => {
 
     await act(async () => {
       const {result, waitForValueToChange} = await renderHook(
-        () => useProposalWithOffchainVoteStatus(proposalData as ProposalData),
+        // Set the `pollInterval` to be a bit quicker
+        () =>
+          useProposalWithOffchainVoteStatus(proposalData as ProposalData, {
+            pollInterval: 2000,
+          }),
         {
           wrapper: Wrapper,
           initialProps: {
@@ -1190,16 +1194,16 @@ describe('useProposalWithOffchainVoteStatus unit tests', () => {
         );
       });
 
-      await waitForValueToChange(() => result.current.status, {timeout: 15000});
+      await waitForValueToChange(() => result.current.status, {timeout: 6000});
 
       // After polling the `status` should change
       await waitFor(() => {
         expect(result.current.status).toBe(ProposalFlowStatus.Process);
       });
     });
-  }, 15000); // Set jest timeout for this test to a higher value to detect polling
+  }, 6000);
 
-  // @note This test uses higher timeouts
+  // @note This test uses adjusted timeouts
   test('should stop polling for data when proposal processed', async () => {
     const proposalData: Partial<ProposalData> = {
       daoProposalVotingAdapter: {
@@ -1226,7 +1230,11 @@ describe('useProposalWithOffchainVoteStatus unit tests', () => {
     let mockWeb3Provider: FakeHttpProvider;
 
     const {result} = renderHook(
-      () => useProposalWithOffchainVoteStatus(proposalData as ProposalData),
+      // Set the `pollInterval` to be a bit quicker
+      () =>
+        useProposalWithOffchainVoteStatus(proposalData as ProposalData, {
+          pollInterval: 2000,
+        }),
       {
         wrapper: Wrapper,
         initialProps: {
@@ -1283,7 +1291,7 @@ describe('useProposalWithOffchainVoteStatus unit tests', () => {
       const helpersToMock = await import('../../web3/helpers/multicall');
       const spy = jest.spyOn(helpersToMock, 'multicall');
 
-      await new Promise((r) => setTimeout(r, 14000));
+      await new Promise((r) => setTimeout(r, 1860));
 
       /**
        * We expect only 1 call as the proposal is processed
@@ -1292,7 +1300,7 @@ describe('useProposalWithOffchainVoteStatus unit tests', () => {
 
       spy.mockRestore();
     });
-  }, 15000); // Set jest timeout for this test to a higher value to detect polling
+  }, 6000);
 
   test('should return error when async call throws on initial fetch', async () => {
     const proposalData: Partial<ProposalData> = {
@@ -1304,7 +1312,11 @@ describe('useProposalWithOffchainVoteStatus unit tests', () => {
     let mockWeb3Provider: FakeHttpProvider;
 
     const {result, waitForValueToChange} = renderHook(
-      () => useProposalWithOffchainVoteStatus(proposalData as ProposalData),
+      // Set the `pollInterval` to be a bit quicker
+      () =>
+        useProposalWithOffchainVoteStatus(proposalData as ProposalData, {
+          pollInterval: 1000,
+        }),
       {
         wrapper: Wrapper,
         initialProps: {
@@ -1364,7 +1376,7 @@ describe('useProposalWithOffchainVoteStatus unit tests', () => {
     });
   });
 
-  // @note This test uses higher timeouts
+  // @note This test uses adjusted timeouts
   test('should return error when async call throws during polling', async () => {
     const proposalData: Partial<ProposalData> = {
       daoProposalVotingAdapter: {
@@ -1392,7 +1404,11 @@ describe('useProposalWithOffchainVoteStatus unit tests', () => {
 
     await act(async () => {
       const {result, waitForValueToChange} = await renderHook(
-        () => useProposalWithOffchainVoteStatus(proposalData as ProposalData),
+        // Set the `pollInterval` to be a bit quicker
+        () =>
+          useProposalWithOffchainVoteStatus(proposalData as ProposalData, {
+            pollInterval: 2000,
+          }),
         {
           wrapper: Wrapper,
           initialProps: {
@@ -1510,12 +1526,12 @@ describe('useProposalWithOffchainVoteStatus unit tests', () => {
       });
 
       await waitForValueToChange(() => result.current.proposalFlowStatusError, {
-        timeout: 15000,
+        timeout: 6000,
       });
 
       expect(result.current.proposalFlowStatusError?.message).toMatch(
         /some bad error\./i
       );
     });
-  }, 15000); // Set jest timeout for this test to a higher value to detect polling
+  }, 6000);
 });


### PR DESCRIPTION
Fixes #360 

✨ **Updates**

 - `useProposalWithOffchainVoteStatus` now has an option for a configurable `pollingInterval`
 - Unit tests for `useProposalWithOffchainVoteStatus` updated to use faster `pollingInterval` of `2000`ms
 - Renames function


