### PR TITLE
Coupon redeem updates to allow any account to redeem on behalf of the coupon recipient

### DIFF
--- a/src/assets/scss/_redeemcard.scss
+++ b/src/assets/scss/_redeemcard.scss
@@ -73,6 +73,10 @@
     }
   }
 
+  .redeemcard__recipient {
+    margin: 0 0 1rem;
+  }
+
   .button {
     min-width: 7.1rem;
   }

--- a/src/hooks/useRedeemCoupon.ts
+++ b/src/hooks/useRedeemCoupon.ts
@@ -165,13 +165,18 @@ export function useRedeemCoupon(): ReturnUseRedeemCoupon {
 
         setSubmitStatus(FetchStatus.FULFILLED);
 
-        // suggest adding DAO token to wallet
-        await addTokenToWallet(erc20Details);
+        // if connected account is the coupon recipient
+        if (
+          redeemableCoupon.recipient.toLowerCase() === account.toLowerCase()
+        ) {
+          // suggest adding DAO token to wallet
+          await addTokenToWallet(erc20Details);
 
-        // re-fetch member
-        await dispatch(
-          getConnectedMember({account, daoRegistryContract, web3Instance})
-        );
+          // re-fetch member
+          await dispatch(
+            getConnectedMember({account, daoRegistryContract, web3Instance})
+          );
+        }
       }
     } catch (error) {
       setSubmitError(error);

--- a/src/pages/redeem/Redeem.tsx
+++ b/src/pages/redeem/Redeem.tsx
@@ -1,7 +1,6 @@
 import {useCallback, useEffect, useState} from 'react';
 import {useLocation} from 'react-router-dom';
 import {useSelector} from 'react-redux';
-// import {toChecksumAddress} from 'web3-utils';
 
 import {StoreState} from '../../store/types';
 import Wrap from '../../components/common/Wrap';
@@ -11,7 +10,6 @@ import {ERC20RegisterDetails} from '../../components/dao-token/DaoToken';
 import RedeemManager from './RedeemManager';
 import {useWeb3Modal} from '../../components/web3/hooks';
 import {COUPON_API_URL} from '../../config';
-// import {truncateEthAddress} from '../../util/helpers/truncateEthAddress';
 import {AsyncStatus} from '../../util/types';
 
 type RedeemCouponType = {
@@ -182,32 +180,10 @@ export default function RedeemCoupon() {
     );
   }
 
-  if (
-    // !redeemableCoupon ||
-    // !redeemableCoupon.length ||
-    // redeemableCoupon[0]?.recipient.toLowerCase() !== account?.toLowerCase()
-    !redeemableCoupon ||
-    !redeemableCoupon.length
-  ) {
+  if (!redeemableCoupon || !redeemableCoupon.length) {
     return (
       <RenderWrapper>
-        <p className="color-brightsalmon">
-          {/* {redeemableCoupon[0]?.recipient ? (
-            <>
-              Connect with{' '}
-              <span className="redeemcard__address--error">
-                {truncateEthAddress(
-                  toChecksumAddress(redeemableCoupon[0].recipient),
-                  7
-                )}
-              </span>{' '}
-              account to view coupon.
-            </>
-          ) : (
-            'Coupon not found for this connected account.'
-          )} */}
-          Coupon not found.
-        </p>
+        <p className="color-brightsalmon">Coupon not found.</p>
       </RenderWrapper>
     );
   }

--- a/src/pages/redeem/Redeem.tsx
+++ b/src/pages/redeem/Redeem.tsx
@@ -1,7 +1,7 @@
 import {useCallback, useEffect, useState} from 'react';
 import {useLocation} from 'react-router-dom';
 import {useSelector} from 'react-redux';
-import {toChecksumAddress} from 'web3-utils';
+// import {toChecksumAddress} from 'web3-utils';
 
 import {StoreState} from '../../store/types';
 import Wrap from '../../components/common/Wrap';
@@ -11,7 +11,7 @@ import {ERC20RegisterDetails} from '../../components/dao-token/DaoToken';
 import RedeemManager from './RedeemManager';
 import {useWeb3Modal} from '../../components/web3/hooks';
 import {COUPON_API_URL} from '../../config';
-import {truncateEthAddress} from '../../util/helpers/truncateEthAddress';
+// import {truncateEthAddress} from '../../util/helpers/truncateEthAddress';
 import {AsyncStatus} from '../../util/types';
 
 type RedeemCouponType = {
@@ -183,14 +183,16 @@ export default function RedeemCoupon() {
   }
 
   if (
+    // !redeemableCoupon ||
+    // !redeemableCoupon.length ||
+    // redeemableCoupon[0]?.recipient.toLowerCase() !== account?.toLowerCase()
     !redeemableCoupon ||
-    !redeemableCoupon.length ||
-    redeemableCoupon[0]?.recipient.toLowerCase() !== account?.toLowerCase()
+    !redeemableCoupon.length
   ) {
     return (
       <RenderWrapper>
         <p className="color-brightsalmon">
-          {redeemableCoupon[0]?.recipient ? (
+          {/* {redeemableCoupon[0]?.recipient ? (
             <>
               Connect with{' '}
               <span className="redeemcard__address--error">
@@ -203,7 +205,8 @@ export default function RedeemCoupon() {
             </>
           ) : (
             'Coupon not found for this connected account.'
-          )}
+          )} */}
+          Coupon not found.
         </p>
       </RenderWrapper>
     );
@@ -229,7 +232,7 @@ function RenderWrapper(props: React.PropsWithChildren<any>): JSX.Element {
 
         <div className="form-wrapper">
           <div className="form__description">
-            <p>Redeem your coupon to get your membership tokens.</p>
+            <p>Redeem coupon to issue the membership tokens.</p>
           </div>
 
           {/* RENDER CHILDREN */}

--- a/src/pages/redeem/RedeemManager.tsx
+++ b/src/pages/redeem/RedeemManager.tsx
@@ -8,7 +8,7 @@ import DaoToken, {
   ERC20RegisterDetails,
 } from '../../components/dao-token/DaoToken';
 import {useRedeemCoupon, FetchStatus} from '../../hooks/useRedeemCoupon';
-import {formatNumber} from '../../util/helpers/formatNumber';
+import {formatNumber, truncateEthAddress} from '../../util/helpers';
 import {Web3TxStatus} from '../../components/web3/types';
 import {TX_CYCLE_MESSAGES} from '../../components/web3/config';
 
@@ -117,6 +117,9 @@ function RedeemCard({redeemable, erc20Details}: RedeemCardProps) {
       className={`redeemcard redeemcard__content ${
         isDone ? 'fireworks' : ''
       } `}>
+      <p className="redeemcard__recipient">
+        Recipient: {truncateEthAddress(redeemable.recipient, 7)}
+      </p>
       <p className="redeemcard__unit">
         {formatNumber(redeemable.amount)}
         <sup>

--- a/src/pages/redeem/RedeemManager.tsx
+++ b/src/pages/redeem/RedeemManager.tsx
@@ -1,3 +1,5 @@
+import {toChecksumAddress} from 'web3-utils';
+
 import {CycleEllipsis} from '../../components/feedback/CycleEllipsis';
 import CycleMessage from '../../components/feedback/CycleMessage';
 import EtherscanURL from '../../components/web3/EtherscanURL';
@@ -118,7 +120,8 @@ function RedeemCard({redeemable, erc20Details}: RedeemCardProps) {
         isDone ? 'fireworks' : ''
       } `}>
       <p className="redeemcard__recipient">
-        Recipient: {truncateEthAddress(redeemable.recipient, 7)}
+        Recipient:{' '}
+        {truncateEthAddress(toChecksumAddress(redeemable.recipient), 7)}
       </p>
       <p className="redeemcard__unit">
         {formatNumber(redeemable.amount)}


### PR DESCRIPTION
Fixes #367

✨ **Updates**

 - Updates coupon redeem page so any connected account can access it to redeem a coupon (even on behalf of another account that will receive the membership units). This is necessary because we will have cases where the coupon recipient cannot redeem the coupon and will need someone else to do it (e.g., due to gas costs).
 - Coupon redeem page UI now includes the recipient address (since the connected account may be different).
 - When a coupon is redeemed, the suggestion to add the DAO token to your wallet is triggered only if the connected account is the coupon recipient (it wouldn't be relevant otherwise).
 - When a coupon is redeemed, re-fetching the connected account info is triggered only if the connected account is the coupon recipient (it wouldn't be relevant otherwise).
