### PR TITLE
Adds ability to pass for `error: () => component` to ErrorMessageWithDetails

### DIFF
--- a/src/components/common/ErrorMessageWithDetails.tsx
+++ b/src/components/common/ErrorMessageWithDetails.tsx
@@ -6,7 +6,7 @@ import FadeIn from './FadeIn';
 
 type ErrorMessageWithDetailsProps = {
   detailsProps?: React.DetailsHTMLAttributes<HTMLDetailsElement>;
-  error: Error | undefined;
+  error: Error | (() => React.ReactElement) | undefined;
   renderText: (() => React.ReactElement) | string;
 };
 
@@ -31,16 +31,18 @@ export default function ErrorMessageWithDetails(
    * @link https://github.com/ethereum/EIPs/blob/master/EIPS/eip-1193.md#provider-errors
    */
   const isWalletRejectedRequest =
-    (error as MetaMaskRPCError)?.code === 4001 ||
-    /^(the )?user rejected (the )?request$/g.test(
-      normalizeString(error?.message || '')
-    );
+    typeof error !== 'function' &&
+    ((error as MetaMaskRPCError)?.code === 4001 ||
+      /^(the )?user rejected (the )?request$/g.test(
+        normalizeString(error?.message || '')
+      ));
 
   const textToDisplay: React.ReactNode =
     typeof renderText === 'string' ? renderText : renderText();
 
   const areErrorMessageAndTextStringSame: boolean =
     typeof renderText === 'string' &&
+    typeof error !== 'function' &&
     normalizeString(renderText) === normalizeString(error?.message || '')
       ? true
       : false;
@@ -65,8 +67,11 @@ export default function ErrorMessageWithDetails(
               style={{cursor: 'pointer', outline: 'none'}}>
               <small>Details</small>
             </summary>
+
             <p className="error-message">
-              <small>{error.message}</small>
+              <small>
+                {typeof error === 'function' ? error() : error.message}
+              </small>
             </p>
           </details>
         )}

--- a/src/components/common/ErrorMessageWithDetails.unit.test.tsx
+++ b/src/components/common/ErrorMessageWithDetails.unit.test.tsx
@@ -13,7 +13,7 @@ class WalletError extends Error {
   }
 }
 
-describe('ErrorMe', () => {
+describe('ErrorMessageWithDetails unit tests', () => {
   test('should return error message with details', () => {
     const {rerender} = render(
       <ErrorMessageWithDetails
@@ -48,18 +48,55 @@ describe('ErrorMe', () => {
     expect(() => screen.getByText(/^Some exotic error\.$/i)).toThrow();
   });
 
-  test('should return error message with details when `error` is function', () => {
+  test('should return error message with details when `renderText` is function', () => {
     render(
       <ErrorMessageWithDetails
-        error={new Error('Some exotic error.')}
-        renderText={() => <span data-testid="exotic-error">Error!</span>}
+        error={new Error('The most exotic error!')}
+        renderText={() => (
+          <span data-testid="exotic-error">Something went wrong</span>
+        )}
       />
     );
 
-    expect(screen.getByText(/^error!$/i)).toBeInTheDocument();
+    expect(screen.getByText(/^something went wrong$/i)).toBeInTheDocument();
     expect(screen.getByText(/^details$/i)).toBeInTheDocument();
-    expect(screen.getByText(/^Some exotic error\.$/i)).toBeInTheDocument();
+    expect(screen.getByText(/^the most exotic error!$/i)).toBeInTheDocument();
     expect(screen.getByTestId('exotic-error')).toBeInTheDocument();
+  });
+
+  test('should return error message with details when `error` is function', () => {
+    render(
+      <ErrorMessageWithDetails
+        error={() => (
+          <span data-testid="exotic-error">The most exotic error!</span>
+        )}
+        renderText="Something went wrong"
+      />
+    );
+
+    expect(screen.getByText(/^something went wrong$/i)).toBeInTheDocument();
+    expect(screen.getByText(/^details$/i)).toBeInTheDocument();
+    expect(screen.getByText(/^the most exotic error!$/i)).toBeInTheDocument();
+    expect(screen.getByTestId('exotic-error')).toBeInTheDocument();
+  });
+
+  test('should return error message with details when both `error` and `renderText` are functions', () => {
+    render(
+      <ErrorMessageWithDetails
+        error={() => (
+          <span data-testid="exotic-error-1">The most exotic error!</span>
+        )}
+        renderText={() => (
+          <span data-testid="exotic-error-2">Another exotic error!</span>
+        )}
+      />
+    );
+
+    expect(screen.getByText(/^another exotic error!$/i)).toBeInTheDocument();
+    expect(screen.getByText(/^details$/i)).toBeInTheDocument();
+    expect(screen.getByText(/^the most exotic error!$/i)).toBeInTheDocument();
+    expect(screen.getByTestId('exotic-error-1')).toBeInTheDocument();
+    expect(screen.getByTestId('exotic-error-2')).toBeInTheDocument();
   });
 
   test('should return `null` if 4001 error code (user rejected wallet tx)', () => {


### PR DESCRIPTION
From work which @jdville03 added into Muse0.

✨ **Updates**

 - Updates `ErrorMessageWithDetails` to also accept for `error` a `() => React.ReactElement`
   - Adds unit tests
 
