### PR TITLE
DaoTokenHolder `delegateKey`

### DIFF
--- a/src/components/dao-token/DaoTokenHolder.tsx
+++ b/src/components/dao-token/DaoTokenHolder.tsx
@@ -62,7 +62,7 @@ export default function DaoTokenHolder(
 
       const holderData = holders?.find(
         (holder: any) =>
-          holder.member.id.toLowerCase() === account.toLowerCase()
+          holder.member.delegateKey.toLowerCase() === account.toLowerCase()
       );
 
       holderData &&

--- a/src/gql/queryTokenHolderBalances.ts
+++ b/src/gql/queryTokenHolderBalances.ts
@@ -9,6 +9,7 @@ export const GET_TOKEN_HOLDER_BALANCES = gql`
         balance
         member {
           id
+          delegateKey
         }
       }
     }


### PR DESCRIPTION
Fixes #375 

✨ **Updates**

 - Check `delegateKey` from gql against connected addr
 - Added `delegateKey` to gql query