### PR TITLE
temporary fix for TokenHolder entity subgraph issue

### DIFF
--- a/src/components/dao-token/DaoTokenHolder.tsx
+++ b/src/components/dao-token/DaoTokenHolder.tsx
@@ -62,7 +62,7 @@ export default function DaoTokenHolder(
 
       const holderData = holders?.find(
         (holder: any) =>
-          holder.member.delegateKey.toLowerCase() === account.toLowerCase()
+          holder.member?.delegateKey.toLowerCase() === account.toLowerCase()
       );
 
       holderData &&


### PR DESCRIPTION
🐞 **Bugs squashed**

 - For the new `TokenHolder` subgraph entity, when an Onboarding proposal is processed, the new member is added to the return result. But a new `null` member is also added. That causes the app to throw an error because `delegateKey` is being applied on the `null` value. This is a temporary fix to address that fatal error in the app.
