### PR TITLE
Member Profile

### DIFF
--- a/src/assets/scss/_delegation.scss
+++ b/src/assets/scss/_delegation.scss
@@ -1,0 +1,80 @@
+@use "./variables" as *; /* load without namespace for convenience */
+@use "./mixins" as *; /* load without namespace for convenience */
+@use "./functions" as *; /* load without namespace for convenience */
+
+.delegation__delegate-address-text {
+  background-color: rgba(214, 216, 218, 0.2);
+  color: $color-primary;
+  margin: 1rem 0;
+  padding: 3px;
+  font-family: $font-mono;
+}
+
+.delegation-modal {
+  p {
+    @include fluid-type(
+      $bp-sm,
+      $bp-xl,
+      16px,
+      18px
+    ); /* min font-size 1rem, max 1.125rem */
+    margin: 0;
+  }
+
+  button.button {
+    min-width: 7.1rem;
+    margin: 1.25rem auto 1.125rem;
+  }
+
+  .form__input-row:first-child {
+    margin-top: 0.5rem;
+  }
+
+  .form__input-row-fieldwrap {
+    flex-basis: initial;
+
+    .error-message {
+      text-align: initial;
+    }
+  }
+
+  .checkbox-text {
+    opacity: initial;
+    @include fluid-type(
+      $bp-sm,
+      $bp-xl,
+      14px,
+      16px
+    ); /* min font-size 0.875rem, max 1rem */
+    text-align: initial;
+  }
+
+  svg[data-icon="user"] {
+    margin-right: 1rem;
+    height: 24px;
+
+    @media only screen and (max-width: em($bp-sm)) {
+      height: 20px;
+    }
+  }
+}
+
+.delegation-modal__arrow-down {
+  @include fluid-type(
+    $bp-sm,
+    $bp-xl,
+    24px,
+    32px
+  ); /* min font-size 1.5rem, max 2rem */
+  margin: 0.5rem 0;
+}
+
+.delegation-modal__text {
+  @include fluid-type(
+    $bp-sm,
+    $bp-xl,
+    14px,
+    16px
+  ); /* min font-size 0.875rem, max 1rem */
+  margin: 1rem;
+}

--- a/src/assets/scss/_membercard.scss
+++ b/src/assets/scss/_membercard.scss
@@ -11,6 +11,10 @@
   &:hover {
     cursor: pointer;
   }
+
+  &--connected-account {
+    box-shadow: 0 2px 2px 0 $color-primary-hover;
+  }
 }
 
 .membercard__title {

--- a/src/assets/scss/_memberprofile.scss
+++ b/src/assets/scss/_memberprofile.scss
@@ -78,3 +78,24 @@
     padding: 0.5rem;
   }
 }
+
+.memberprofile__info-item {
+  display: flex;
+  flex-direction: column;
+  word-wrap: break-word;
+  @include fluid-type(
+    $bp-sm,
+    $bp-xl,
+    16px,
+    18px
+  ); /* min font-size 1rem, max 1.125rem */
+
+  &:not(:last-child) {
+    margin-bottom: 2rem;
+  }
+
+  & > span:first-child {
+    margin-bottom: 0.5rem;
+    font-weight: 500;
+  }
+}

--- a/src/assets/scss/_memberprofile.scss
+++ b/src/assets/scss/_memberprofile.scss
@@ -1,5 +1,6 @@
 @use "./variables" as *; /* load without namespace for convenience */
 @use "./mixins" as *; /* load without namespace for convenience */
+@use "./button";
 
 .memberprofile__header {
   display: inline-block;
@@ -129,4 +130,31 @@
       16px
     ); /* min font-size 0.875rem, max 1rem */
   }
+}
+
+.memberprofile__action-button {
+  @extend .button--secondary;
+
+  @include fluid-type(
+    $bp-sm,
+    $bp-xl,
+    16px,
+    18px
+  ); /* min font-size 1rem, max 1.125rem */
+  width: 100%;
+  margin: 1.5rem 0;
+  display: block;
+  max-width: 20rem;
+}
+
+.memberprofile__actions-unavailable {
+  @include fluid-type(
+    $bp-sm,
+    $bp-xl,
+    16px,
+    18px
+  ); /* min font-size 1rem, max 1.125rem */
+  height: 100%;
+  display: flex;
+  align-items: center;
 }

--- a/src/assets/scss/_memberprofile.scss
+++ b/src/assets/scss/_memberprofile.scss
@@ -28,9 +28,9 @@
 }
 
 .memberprofile__left-column {
-  padding: 1.5rem 5rem 1.5rem 1.5rem;
-  flex: 0 55%;
-  min-width: 55%;
+  padding: 1.5rem;
+  flex: 0 50%;
+  min-width: 50%;
   word-break: break-word;
 
   p {
@@ -67,11 +67,12 @@
 }
 
 .memberprofile__right-column {
-  padding: 1.5rem 2rem;
-  flex: 0 45%;
+  padding: 1.5rem;
+  flex: 0 50%;
 
   @include size-medium-down {
     padding: 1rem;
+    margin-top: 1rem;
   }
 
   @include size-down-down {
@@ -94,8 +95,38 @@
     margin-bottom: 2rem;
   }
 
-  & > span:first-child {
+  & > div:first-child {
     margin-bottom: 0.5rem;
     font-weight: 500;
+  }
+}
+
+.memberprofile__action {
+  display: flex;
+  flex-direction: column;
+  word-wrap: break-word;
+  @include fluid-type(
+    $bp-sm,
+    $bp-xl,
+    16px,
+    18px
+  ); /* min font-size 1rem, max 1.125rem */
+
+  &:not(:last-child) {
+    margin-bottom: 2rem;
+  }
+
+  .memberprofile__action-header {
+    margin-bottom: 0.5rem;
+    font-weight: 500;
+  }
+
+  .memberprofile__action-description {
+    @include fluid-type(
+      $bp-sm,
+      $bp-xl,
+      14px,
+      16px
+    ); /* min font-size 0.875rem, max 1rem */
   }
 }

--- a/src/assets/scss/_modal.scss
+++ b/src/assets/scss/_modal.scss
@@ -59,6 +59,12 @@
 
 .modal__subtitle {
   font-size: 1.125rem;
+  @include fluid-type(
+    $bp-sm,
+    $bp-xl,
+    16px,
+    18px
+  ); /* min font-size 1rem, max 1.125rem */
   margin-bottom: 1.5rem;
 }
 

--- a/src/assets/scss/style.scss
+++ b/src/assets/scss/style.scss
@@ -29,6 +29,7 @@
 @use "./redeemcard"; /* redeem card styles */
 @use "./daotoken"; /* DAO token widget styles */
 @use "./daotokenholder"; /* DAO token holder widget styles */
+@use "./delegation"; /* delegation styles */
 
 html {
   height: 100%;

--- a/src/assets/svg/UserSVG.tsx
+++ b/src/assets/svg/UserSVG.tsx
@@ -1,0 +1,18 @@
+import {SVGAttributes} from 'react';
+
+export default function UserSVG(props: SVGAttributes<HTMLOrSVGElement>) {
+  return (
+    <svg
+      aria-hidden="true"
+      focusable="false"
+      data-icon="user"
+      role="img"
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 448 512"
+      {...props}>
+      <path
+        fill="currentColor"
+        d="M313.6 304c-28.7 0-42.5 16-89.6 16-47.1 0-60.8-16-89.6-16C60.2 304 0 364.2 0 438.4V464c0 26.5 21.5 48 48 48h352c26.5 0 48-21.5 48-48v-25.6c0-74.2-60.2-134.4-134.4-134.4zM400 464H48v-25.6c0-47.6 38.8-86.4 86.4-86.4 14.6 0 38.3 16 89.6 16 51.7 0 74.9-16 89.6-16 47.6 0 86.4 38.8 86.4 86.4V464zM224 288c79.5 0 144-64.5 144-144S303.5 0 224 0 80 64.5 80 144s64.5 144 144 144zm0-240c52.9 0 96 43.1 96 96s-43.1 96-96 96-96-43.1-96-96 43.1-96 96-96z"></path>
+    </svg>
+  );
+}

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -11,7 +11,6 @@ import {useWeb3Modal} from './web3/hooks';
 import HamburgerSVG from '../assets/svg/HamburgerSVG';
 import TimesSVG from '../assets/svg/TimesSVG';
 import Web3ModalButton from './web3/Web3ModalButton';
-import DaoTokenHolder from './dao-token/DaoTokenHolder';
 
 // see: http://reactcommunity.org/react-transition-group/transition
 const duration = 200;
@@ -175,7 +174,6 @@ export function NavHamburger() {
 
                 <div className="nav-modal__walletconnect-button-container">
                   <Web3ModalButton showWalletETHBadge />
-                  <DaoTokenHolder border={'1px solid #c3d6dc'} />
                 </div>
                 <ul className="nav__list">
                   <li

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -11,6 +11,7 @@ import {useWeb3Modal} from './web3/hooks';
 import HamburgerSVG from '../assets/svg/HamburgerSVG';
 import TimesSVG from '../assets/svg/TimesSVG';
 import Web3ModalButton from './web3/Web3ModalButton';
+import DaoTokenHolder from './dao-token/DaoTokenHolder';
 
 // see: http://reactcommunity.org/react-transition-group/transition
 const duration = 200;

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -175,6 +175,7 @@ export function NavHamburger() {
 
                 <div className="nav-modal__walletconnect-button-container">
                   <Web3ModalButton showWalletETHBadge />
+                  <DaoTokenHolder border={'1px solid #c3d6dc'} />
                 </div>
                 <ul className="nav__list">
                   <li

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -68,9 +68,7 @@ export function NavHamburger() {
    * Selectors
    */
 
-  const isActiveMember = useSelector(
-    (s: StoreState) => s.connectedMember?.isActiveMember
-  );
+  const connectedMember = useSelector((s: StoreState) => s.connectedMember);
 
   /**
    * State
@@ -103,6 +101,19 @@ export function NavHamburger() {
       closeMenuRef.current && clearTimeout(closeMenuRef.current);
     };
   }, []);
+
+  /**
+   * Variables
+   */
+
+  const isCurrentMemberOrDelegateConnected: boolean =
+    account && connectedMember?.isActiveMember ? true : false;
+  const isCurrentMemberConnected: boolean =
+    account &&
+    connectedMember?.isActiveMember &&
+    account.toLowerCase() === connectedMember?.memberAddress.toLowerCase()
+      ? true
+      : false;
 
   /**
    * Functions
@@ -209,25 +220,27 @@ export function NavHamburger() {
                       <span>Tribute</span>
                     </NavLink>
                   </li>
-                  {account && isActiveMember && (
-                    <>
-                      <li
-                        onClick={() => {
-                          handleMenuModalClose(false);
-                        }}>
-                        <NavLink to={`/members/${account}`}>
-                          <span>Profile</span>
-                        </NavLink>
-                      </li>
-                      <li
-                        onClick={() => {
-                          handleMenuModalClose(false);
-                        }}>
-                        <NavLink to="/dao-manager">
-                          <span>Manage DAO</span>
-                        </NavLink>
-                      </li>
-                    </>
+                  {/* The Profile link is available to only the connected member user (not any delegate) because the profile exists for the member account. */}
+                  {isCurrentMemberConnected && (
+                    <li
+                      onClick={() => {
+                        handleMenuModalClose(false);
+                      }}>
+                      <NavLink to={`/members/${account}`}>
+                        <span>Profile</span>
+                      </NavLink>
+                    </li>
+                  )}
+                  {/* The Manage DAO link is available to both connected member users and connected delegate users. */}
+                  {isCurrentMemberOrDelegateConnected && (
+                    <li
+                      onClick={() => {
+                        handleMenuModalClose(false);
+                      }}>
+                      <NavLink to="/dao-manager">
+                        <span>Manage DAO</span>
+                      </NavLink>
+                    </li>
                   )}
                 </ul>
               </div>

--- a/src/components/dao-token/DaoToken.tsx
+++ b/src/components/dao-token/DaoToken.tsx
@@ -10,23 +10,25 @@ export type ERC20RegisterDetails = {
 };
 
 type DaoTokenProps = {
-  erc20Details?: ERC20RegisterDetails;
+  daoTokenDetails?: ERC20RegisterDetails;
 };
 
-export default function DaoToken({erc20Details}: DaoTokenProps): JSX.Element {
+export default function DaoToken({
+  daoTokenDetails,
+}: DaoTokenProps): JSX.Element {
   /**
    * Functions
    */
 
   async function addTokenToWallet() {
-    if (!erc20Details) return;
+    if (!daoTokenDetails) return;
 
     try {
       await window.ethereum.request({
         method: 'wallet_watchAsset',
         params: {
           type: 'ERC20',
-          options: erc20Details,
+          options: daoTokenDetails,
         },
       });
     } catch (error) {
@@ -35,10 +37,11 @@ export default function DaoToken({erc20Details}: DaoTokenProps): JSX.Element {
   }
 
   function copyAddressToClipboard() {
-    if (!erc20Details) return;
+    if (!daoTokenDetails) return;
+
     const copyText = document.createElement('input');
     document.body.appendChild(copyText);
-    copyText.setAttribute('value', erc20Details.address);
+    copyText.setAttribute('value', daoTokenDetails.address);
     copyText.select();
     document.execCommand('copy');
     document.body.removeChild(copyText);
@@ -56,10 +59,10 @@ export default function DaoToken({erc20Details}: DaoTokenProps): JSX.Element {
    * Render
    */
 
-  if (erc20Details) {
+  if (daoTokenDetails) {
     return (
       <div>
-        Token: <span>{truncateEthAddress(erc20Details.address, 7)}</span>
+        Token: <span>{truncateEthAddress(daoTokenDetails.address, 7)}</span>
         <div className="daotoken__tooltip">
           <button
             className="daotoken__button"

--- a/src/components/dao-token/DaoTokenHolder.tsx
+++ b/src/components/dao-token/DaoTokenHolder.tsx
@@ -62,7 +62,7 @@ export default function DaoTokenHolder(
 
       const holderData = holders?.find(
         (holder: any) =>
-          holder.member?.delegateKey.toLowerCase() === account.toLowerCase()
+          holder.member?.id.toLowerCase() === account.toLowerCase()
       );
 
       holderData &&

--- a/src/components/dao-token/DaoTokenHolder.tsx
+++ b/src/components/dao-token/DaoTokenHolder.tsx
@@ -2,7 +2,7 @@ import {useCallback, useEffect, useState} from 'react';
 
 import FadeIn from '../../components/common/FadeIn';
 import {useWeb3Modal} from '../../components/web3/hooks';
-import {useTokenHolderBalances} from '../../hooks';
+import {useTokenHolderBalances} from './hooks';
 
 import {formatNumber} from '../../util/helpers';
 import {ETHERSCAN_URLS} from '../../config';

--- a/src/components/dao-token/hooks/index.ts
+++ b/src/components/dao-token/hooks/index.ts
@@ -1,0 +1,2 @@
+export * from './useDaoTokenDetails';
+export * from './useTokenHolderBalances';

--- a/src/components/dao-token/hooks/useDaoTokenDetails.ts
+++ b/src/components/dao-token/hooks/useDaoTokenDetails.ts
@@ -11,6 +11,13 @@ type UseDaoTokenDetailsReturn = {
   daoTokenDetailsStatus: AsyncStatus;
 };
 
+/**
+ * useDaoTokenDetails
+ *
+ * Gets DAO token details from ERC20Extension contract.
+ *
+ * @returns {UseDaoTokenDetailsReturn}
+ */
 export function useDaoTokenDetails(): UseDaoTokenDetailsReturn {
   /**
    * Selectors

--- a/src/components/dao-token/hooks/useDaoTokenDetails.ts
+++ b/src/components/dao-token/hooks/useDaoTokenDetails.ts
@@ -1,0 +1,83 @@
+import {useCallback, useEffect, useState} from 'react';
+import {useSelector} from 'react-redux';
+
+import {StoreState} from '../../../store/types';
+import {ERC20RegisterDetails} from '../DaoToken';
+import {AsyncStatus} from '../../../util/types';
+
+type UseDaoTokenDetailsReturn = {
+  daoTokenDetails: ERC20RegisterDetails | undefined;
+  daoTokenDetailsError: Error | undefined;
+  daoTokenDetailsStatus: AsyncStatus;
+};
+
+export function useDaoTokenDetails(): UseDaoTokenDetailsReturn {
+  /**
+   * Selectors
+   */
+
+  const ERC20ExtensionContract = useSelector(
+    (state: StoreState) => state.contracts?.ERC20ExtensionContract
+  );
+
+  /**
+   * State
+   */
+
+  const [daoTokenDetails, setDaoTokenDetails] =
+    useState<ERC20RegisterDetails>();
+  const [daoTokenDetailsStatus, setDaoTokenDetailsStatus] =
+    useState<AsyncStatus>(AsyncStatus.STANDBY);
+  const [daoTokenDetailsError, setDaoTokenDetailsError] = useState<Error>();
+
+  /**
+   * Cached callbacks
+   */
+
+  const getDaoTokenDetailsCached = useCallback(getDaoTokenDetails, [
+    ERC20ExtensionContract,
+  ]);
+
+  /**
+   * Effects
+   */
+
+  useEffect(() => {
+    getDaoTokenDetailsCached();
+  }, [getDaoTokenDetailsCached]);
+
+  /**
+   * Functions
+   */
+
+  async function getDaoTokenDetails() {
+    if (!ERC20ExtensionContract) return;
+
+    try {
+      setDaoTokenDetailsStatus(AsyncStatus.PENDING);
+
+      const symbol = await ERC20ExtensionContract.instance.methods
+        .symbol()
+        .call();
+      const decimals = await ERC20ExtensionContract.instance.methods
+        .decimals()
+        .call();
+
+      setDaoTokenDetails({
+        address: ERC20ExtensionContract.contractAddress,
+        symbol,
+        decimals: Number(decimals),
+        image: `${window.location.origin}/favicon.ico`,
+      });
+
+      setDaoTokenDetailsStatus(AsyncStatus.FULFILLED);
+    } catch (error) {
+      console.log(error);
+      setDaoTokenDetails(undefined);
+      setDaoTokenDetailsError(error);
+      setDaoTokenDetailsStatus(AsyncStatus.REJECTED);
+    }
+  }
+
+  return {daoTokenDetails, daoTokenDetailsError, daoTokenDetailsStatus};
+}

--- a/src/components/dao-token/hooks/useTokenHolderBalances.ts
+++ b/src/components/dao-token/hooks/useTokenHolderBalances.ts
@@ -1,10 +1,10 @@
 import {useCallback, useEffect, useState} from 'react';
 import {useLazyQuery} from '@apollo/react-hooks';
 
-import {StoreState} from '../store/types';
+import {StoreState} from '../../../store/types';
 import {useSelector} from 'react-redux';
 
-import {GET_TOKEN_HOLDER_BALANCES} from '../gql';
+import {GET_TOKEN_HOLDER_BALANCES} from '../../../gql';
 
 type UseTokenHolderBalancesReturn = {
   tokenHolderBalances: Record<string, any> | undefined;

--- a/src/components/dao-token/hooks/useTokenHolderBalances.unit.test.ts
+++ b/src/components/dao-token/hooks/useTokenHolderBalances.unit.test.ts
@@ -1,9 +1,9 @@
 import {act, renderHook} from '@testing-library/react-hooks';
 import {createMockClient} from 'mock-apollo-client';
-import {GET_TOKEN_HOLDER_BALANCES} from '../gql';
-import {tokenHolderBalancesResponse} from '../test/gqlResponses';
+import {GET_TOKEN_HOLDER_BALANCES} from '../../../gql';
+import {tokenHolderBalancesResponse} from '../../../test/gqlResponses';
 import {useTokenHolderBalances} from './useTokenHolderBalances';
-import Wrapper from '../test/Wrapper';
+import Wrapper from '../../../test/Wrapper';
 
 const mockClient = createMockClient();
 

--- a/src/components/proposals/ProcessActionMembership.tsx
+++ b/src/components/proposals/ProcessActionMembership.tsx
@@ -2,7 +2,7 @@ import {useState, useRef, useEffect, useCallback} from 'react';
 import {useDispatch, useSelector} from 'react-redux';
 
 import {CycleEllipsis} from '../feedback';
-import {ERC20RegisterDetails} from '../dao-token/DaoToken';
+import {useDaoTokenDetails} from '../dao-token/hooks';
 import {getConnectedMember} from '../../store/actions';
 import {ProposalData, SnapshotProposal} from './types';
 import {ReduxDispatch, StoreState} from '../../store/types';
@@ -56,6 +56,7 @@ export default function ProcessActionMembership(
   const [submitError, setSubmitError] = useState<Error>();
   const [membershipProposalAmount, setMembershipProposalAmount] =
     useState<string>();
+  const {daoTokenDetails} = useDaoTokenDetails();
 
   /**
    * Refs
@@ -75,15 +76,6 @@ export default function ProcessActionMembership(
   const daoRegistryContract = useSelector(
     (s: StoreState) => s.contracts.DaoRegistryContract
   );
-  const ERC20ExtensionContract = useSelector(
-    (state: StoreState) => state.contracts?.ERC20ExtensionContract
-  );
-
-  /**
-   * State
-   */
-
-  const [erc20Details, setERC20Details] = useState<ERC20RegisterDetails>();
 
   /**
    * Our hooks
@@ -124,9 +116,6 @@ export default function ProcessActionMembership(
     getMembershipProposalAmount,
     [OnboardingContract, daoRegistryContract?.contractAddress, snapshotProposal]
   );
-  const getERC20DetailsCached = useCallback(getERC20Details, [
-    ERC20ExtensionContract,
-  ]);
 
   /**
    * Effects
@@ -163,24 +152,6 @@ export default function ProcessActionMembership(
     // 2. Set reasons
     setOtherDisabledReasons(Object.values(actionDisabledReasonsRef.current));
   }, [account, setOtherDisabledReasons, snapshotProposal]);
-
-  // Prepare DAO token info if original proposer is processing proposal
-  useEffect(() => {
-    // Proposals of this type will have this value stored in its snapshot
-    // metadata.
-    const {accountAuthorizedToProcessPassedProposal} = (
-      snapshotProposal as SnapshotProposal
-    ).msg.payload.metadata;
-
-    if (accountAuthorizedToProcessPassedProposal && account) {
-      if (
-        accountAuthorizedToProcessPassedProposal.toLowerCase() ===
-        account.toLowerCase()
-      ) {
-        getERC20DetailsCached();
-      }
-    }
-  }, [account, getERC20DetailsCached, snapshotProposal]);
 
   /**
    * Functions
@@ -260,42 +231,18 @@ export default function ProcessActionMembership(
   }
 
   async function addTokenToWallet() {
-    if (!erc20Details) return;
+    if (!daoTokenDetails) return;
 
     try {
       await window.ethereum.request({
         method: 'wallet_watchAsset',
         params: {
           type: 'ERC20',
-          options: erc20Details,
+          options: daoTokenDetails,
         },
       });
     } catch (error) {
       console.log(error);
-    }
-  }
-
-  async function getERC20Details() {
-    if (!ERC20ExtensionContract) return;
-
-    try {
-      const address = ERC20ExtensionContract.contractAddress;
-      const symbol = await ERC20ExtensionContract.instance.methods
-        .symbol()
-        .call();
-      const decimals = await ERC20ExtensionContract.instance.methods
-        .decimals()
-        .call();
-      const image = `${window.location.origin}/favicon.ico`;
-      setERC20Details({
-        address,
-        symbol,
-        decimals: Number(decimals),
-        image,
-      });
-    } catch (error) {
-      console.log(error);
-      setERC20Details(undefined);
     }
   }
 

--- a/src/components/proposals/voting/OffchainVotingAction.tsx
+++ b/src/components/proposals/voting/OffchainVotingAction.tsx
@@ -1,5 +1,6 @@
 import {useEffect, useRef, useState} from 'react';
 
+import {truncateEthAddress} from '../../../util/helpers';
 import {ContractAdapterNames, Web3TxStatus} from '../../web3/types';
 import {getVoteChosen} from '../helpers';
 import {ProposalData} from '../types';
@@ -23,7 +24,10 @@ type VotingDisabledReasons = {
 };
 
 const getDelegatedAddressMessage = (a: string) =>
-  `Your member address is delegated to ${a}. You must use that address to vote.`;
+  `Your member address is delegated to ${truncateEthAddress(
+    a,
+    7
+  )}. You must use that address to vote.`;
 
 /**
  * OffchainVotingAction

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,6 +1,7 @@
 export * from './useAbortController';
 export * from './useCounter';
 export * from './useDao';
+export * from './useDaoTotalUnits';
 export * from './useIsMounted';
 export * from './useMemberActionDisabled';
 export * from './useRedeemCoupon';

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -4,4 +4,3 @@ export * from './useDao';
 export * from './useIsMounted';
 export * from './useMemberActionDisabled';
 export * from './useRedeemCoupon';
-export * from './useTokenHolderBalances';

--- a/src/hooks/useDaoTotalUnits.ts
+++ b/src/hooks/useDaoTotalUnits.ts
@@ -1,0 +1,135 @@
+import {useCallback, useEffect, useState} from 'react';
+import {useLazyQuery} from '@apollo/react-hooks';
+import {useSelector} from 'react-redux';
+
+import {AsyncStatus} from '../util/types';
+import {StoreState} from '../store/types';
+import {SubgraphNetworkStatus} from '../store/subgraphNetworkStatus/types';
+import {GET_DAO} from '../gql';
+import {GQL_QUERY_POLLING_INTERVAL} from '../config';
+
+type UseDaoTotalUnitsReturn = {
+  totalUnits: number | undefined;
+  totalUnitsError: Error | undefined;
+  totalUnitsStatus: AsyncStatus;
+};
+
+export function useDaoTotalUnits(): UseDaoTotalUnitsReturn {
+  /**
+   * Selectors
+   */
+
+  const DaoRegistryContract = useSelector(
+    (state: StoreState) => state.contracts.DaoRegistryContract
+  );
+  const BankExtensionContract = useSelector(
+    (state: StoreState) => state.contracts.BankExtensionContract
+  );
+  const subgraphNetworkStatus = useSelector(
+    (state: StoreState) => state.subgraphNetworkStatus.status
+  );
+
+  /**
+   * GQL Query
+   */
+
+  const [
+    getDaoFromSubgraphResult,
+    {called, loading, data, error, stopPolling},
+  ] = useLazyQuery(GET_DAO, {
+    pollInterval: GQL_QUERY_POLLING_INTERVAL,
+    variables: {
+      id: DaoRegistryContract?.contractAddress.toLowerCase(),
+    },
+  });
+
+  /**
+   * State
+   */
+
+  const [totalUnits, setTotalUnits] = useState<number>();
+  const [totalUnitsStatus, setTotalUnitsStatus] = useState<AsyncStatus>(
+    AsyncStatus.STANDBY
+  );
+  const [totalUnitsError, setTotalUnitsError] = useState<Error>();
+
+  /**
+   * Cached callbacks
+   */
+
+  const getTotalUnitsFromExtensionCached = useCallback(
+    getTotalUnitsFromExtension,
+    []
+  );
+
+  const getTotalUnitsFromSubgraphCached = useCallback(
+    getTotalUnitsFromSubgraph,
+    []
+  );
+
+  /**
+   * Effects
+   */
+
+  useEffect(() => {
+    if (!called) {
+      getDaoFromSubgraphResult();
+    }
+  }, []);
+
+  useEffect(() => {
+    if (subgraphNetworkStatus === SubgraphNetworkStatus.OK) {
+      if (!loading && DaoRegistryContract?.contractAddress) {
+        getTotalUnitsFromSubgraphCached();
+      }
+    } else {
+      // If there is a subgraph network error fallback to fetching totalUnits
+      // directly from smart contract
+      stopPolling && stopPolling();
+      getTotalUnitsFromExtensionCached();
+    }
+  }, []);
+
+  /**
+   * Functions
+   */
+
+  function getTotalUnitsFromSubgraph() {
+    try {
+      setTotalUnitsStatus(AsyncStatus.PENDING);
+
+      if (!loading && data) {
+        // extract totalUnits from gql data
+        const {totalUnits} = data.tributeDaos[0] as Record<string, any>;
+        setTotalUnits(Number(totalUnits));
+        setTotalUnitsStatus(AsyncStatus.FULFILLED);
+      } else {
+        if (error) {
+          throw new Error(error.message);
+        }
+      }
+    } catch (error) {
+      // If there is a subgraph query error fallback to fetching totalUnits
+      // directly from smart contract
+      console.log(`subgraph query error: ${error.message}`);
+      stopPolling && stopPolling();
+      getTotalUnitsFromExtensionCached();
+    }
+  }
+
+  async function getTotalUnitsFromExtension() {
+    if (!BankExtensionContract) {
+      return;
+    }
+
+    try {
+      setTotalUnitsStatus(AsyncStatus.PENDING);
+    } catch (error) {
+      setTotalUnits(undefined);
+      setTotalUnits(error);
+      setTotalUnitsStatus(AsyncStatus.REJECTED);
+    }
+  }
+
+  return {totalUnits, totalUnitsError, totalUnitsStatus};
+}

--- a/src/hooks/useDaoTotalUnits.ts
+++ b/src/hooks/useDaoTotalUnits.ts
@@ -6,11 +6,7 @@ import {AsyncStatus} from '../util/types';
 import {StoreState} from '../store/types';
 import {SubgraphNetworkStatus} from '../store/subgraphNetworkStatus/types';
 import {GET_DAO} from '../gql';
-import {
-  GQL_QUERY_POLLING_INTERVAL,
-  TOTAL_ADDRESS,
-  UNITS_ADDRESS,
-} from '../config';
+import {TOTAL_ADDRESS, UNITS_ADDRESS} from '../config';
 
 type UseDaoTotalUnitsReturn = {
   totalUnits: number | undefined;
@@ -44,15 +40,12 @@ export function useDaoTotalUnits(): UseDaoTotalUnitsReturn {
    * GQL Query
    */
 
-  const [
-    getDaoFromSubgraphResult,
-    {called, loading, data, error, stopPolling},
-  ] = useLazyQuery(GET_DAO, {
-    pollInterval: GQL_QUERY_POLLING_INTERVAL,
-    variables: {
-      id: DaoRegistryContract?.contractAddress.toLowerCase(),
-    },
-  });
+  const [getDaoFromSubgraphResult, {called, loading, data, error}] =
+    useLazyQuery(GET_DAO, {
+      variables: {
+        id: DaoRegistryContract?.contractAddress.toLowerCase(),
+      },
+    });
 
   /**
    * State
@@ -75,7 +68,7 @@ export function useDaoTotalUnits(): UseDaoTotalUnitsReturn {
 
   const getTotalUnitsFromSubgraphCached = useCallback(
     getTotalUnitsFromSubgraph,
-    [data, error, getTotalUnitsFromExtensionCached, loading, stopPolling]
+    [data, error, getTotalUnitsFromExtensionCached, loading]
   );
 
   /**
@@ -96,7 +89,6 @@ export function useDaoTotalUnits(): UseDaoTotalUnitsReturn {
     } else {
       // If there is a subgraph network error fallback to fetching totalUnits
       // directly from smart contract
-      stopPolling && stopPolling();
       getTotalUnitsFromExtensionCached();
     }
   }, [
@@ -104,7 +96,6 @@ export function useDaoTotalUnits(): UseDaoTotalUnitsReturn {
     getTotalUnitsFromExtensionCached,
     getTotalUnitsFromSubgraphCached,
     loading,
-    stopPolling,
     subgraphNetworkStatus,
   ]);
 
@@ -130,7 +121,6 @@ export function useDaoTotalUnits(): UseDaoTotalUnitsReturn {
       // If there is a subgraph query error fallback to fetching totalUnits
       // directly from smart contract
       console.log(`subgraph query error: ${error.message}`);
-      stopPolling && stopPolling();
       getTotalUnitsFromExtensionCached();
     }
   }

--- a/src/pages/members/Delegation.tsx
+++ b/src/pages/members/Delegation.tsx
@@ -1,0 +1,580 @@
+import {useState, useEffect, useCallback} from 'react';
+import {useDispatch, useSelector} from 'react-redux';
+import {useForm} from 'react-hook-form';
+import {toChecksumAddress} from 'web3-utils';
+
+import {
+  useWeb3Modal,
+  useContractSend,
+  useETHGasPrice,
+} from '../../components/web3/hooks';
+import {Web3TxStatus} from '../../components/web3/types';
+import {TX_CYCLE_MESSAGES} from '../../components/web3/config';
+import EtherscanURL from '../../components/web3/EtherscanURL';
+import {FormFieldErrors} from '../../util/enums';
+import {isEthAddressValid} from '../../util/validation';
+import {getValidationError, truncateEthAddress} from '../../util/helpers';
+import {BURN_ADDRESS} from '../../util/constants';
+import {getConnectedMember} from '../../store/actions';
+import {ReduxDispatch, StoreState} from '../../store/types';
+import {CheckboxSize} from '../../components/common/Checkbox';
+import Loader from '../../components/feedback/Loader';
+import CycleMessage from '../../components/feedback/CycleMessage';
+import Modal from '../../components/common/Modal';
+import TimesSVG from '../../assets/svg/TimesSVG';
+import UserSVG from '../../assets/svg/UserSVG';
+import FadeIn from '../../components/common/FadeIn';
+import InputError from '../../components/common/InputError';
+import ErrorMessageWithDetails from '../../components/common/ErrorMessageWithDetails';
+
+enum DelegationStatus {
+  DELEGATE_VOTES = 'Delegate Votes',
+  REVOKE_DELEGATION = 'Revoke Delegation',
+}
+
+enum DelegationStep {
+  SET_DELEGATION = 'setDelegation',
+  REVOKE_DELEGATION = 'revokeDelegation',
+}
+
+enum Fields {
+  delegateAddress = 'delegateAddress',
+  confirmDelegation = 'confirmDelegation',
+}
+
+type Steps = 'setDelegation' | 'revokeDelegation';
+
+type StepsType = {[S in Steps]: () => JSX.Element};
+
+type FormInputs = {
+  delegateAddress: string;
+  confirmDelegation: boolean;
+};
+
+type UpdateDelegateKeyArguments = [
+  string, // `dao`
+  string // `delegateKey`
+];
+
+type DelegationModalProps = {
+  isOpen: boolean;
+  closeHandler: () => void;
+  currentStep: string;
+};
+
+function DelegationModal({
+  isOpen,
+  closeHandler,
+  currentStep,
+}: DelegationModalProps): JSX.Element {
+  /**
+   * Selectors
+   */
+
+  const daoRegistryContract = useSelector(
+    (state: StoreState) => state.contracts.DaoRegistryContract
+  );
+  const daoRegistryAdapterContract = useSelector(
+    (state: StoreState) => state.contracts.DaoRegistryAdapterContract
+  );
+  const connectedMember = useSelector((s: StoreState) => s.connectedMember);
+
+  /**
+   * Our hooks
+   */
+
+  const {account, web3Instance} = useWeb3Modal();
+  const gasPrices = useETHGasPrice();
+  const {txError, txEtherscanURL, txIsPromptOpen, txSend, txStatus} =
+    useContractSend();
+
+  /**
+   * Their hooks
+   */
+
+  const form = useForm<FormInputs>({
+    mode: 'onBlur',
+    reValidateMode: 'onChange',
+  });
+  const dispatch = useDispatch<ReduxDispatch>();
+
+  /**
+   * State
+   */
+
+  const [submitError, setSubmitError] = useState<Error>();
+
+  /**
+   * Variables
+   */
+
+  const {errors, getValues, register, trigger, watch} = form;
+  const isInProcess =
+    txStatus === Web3TxStatus.AWAITING_CONFIRM ||
+    txStatus === Web3TxStatus.PENDING;
+  const isDone = txStatus === Web3TxStatus.FULFILLED;
+  const isInProcessOrDone = isInProcess || isDone || txIsPromptOpen;
+  const delegateError = submitError || txError;
+
+  const delegateAddressValue = watch(Fields.delegateAddress);
+  const confirmDelegationValue = watch(Fields.confirmDelegation);
+  const isFormFieldEmpty = !delegateAddressValue || !confirmDelegationValue;
+  const steps: StepsType = {
+    setDelegation: renderSetDelegation,
+    revokeDelegation: renderRevokeDelegation,
+  };
+
+  /**
+   * Functions
+   */
+
+  function renderCurrentStep() {
+    return steps[currentStep]();
+  }
+
+  function renderSetDelegation() {
+    return (
+      <>
+        {/* TITLE */}
+        <div className="modal__title">Delegate</div>
+
+        <p>Transfer your voting rights</p>
+        <div className="delegation-modal__arrow-down">&darr;</div>
+        <form className="form" onSubmit={(e) => e.preventDefault()}>
+          {/* DELEGATE ADDRESS */}
+          <div className="form__input-row">
+            <div className="form__input-row-fieldwrap">
+              <input
+                aria-describedby={`error-${Fields.delegateAddress}`}
+                aria-invalid={errors.delegateAddress ? 'true' : 'false'}
+                name={Fields.delegateAddress}
+                ref={register({
+                  validate: (delegateAddress: string): string | boolean => {
+                    return !delegateAddress
+                      ? FormFieldErrors.REQUIRED
+                      : !isEthAddressValid(delegateAddress) ||
+                        delegateAddress === BURN_ADDRESS
+                      ? FormFieldErrors.INVALID_ETHEREUM_ADDRESS
+                      : true;
+                  },
+                })}
+                type="text"
+                disabled={isInProcessOrDone}
+                placeholder="Enter delegate address"
+              />
+
+              {getValidationError(Fields.delegateAddress, errors).includes(
+                'invalid'
+              ) && (
+                <InputError
+                  error={getValidationError(Fields.delegateAddress, errors)}
+                  id={`error-${Fields.delegateAddress}`}
+                />
+              )}
+            </div>
+          </div>
+
+          {/* CONFIRM DELEGATION */}
+          <div className="form__input-row" style={{marginTop: 0}}>
+            <div className="form__input-row-fieldwrap">
+              <input
+                className="checkbox-input"
+                aria-describedby={`error-${Fields.confirmDelegation}`}
+                aria-invalid={errors.confirmDelegation ? 'true' : 'false'}
+                id={Fields.confirmDelegation}
+                name={Fields.confirmDelegation}
+                ref={register({
+                  required: FormFieldErrors.REQUIRED,
+                })}
+                type="checkbox"
+                disabled={isInProcessOrDone}
+              />
+
+              <label
+                className="checkbox-label"
+                htmlFor={Fields.confirmDelegation}>
+                <span className={`checkbox-box ${CheckboxSize.SMALL}`}></span>
+                <span className="checkbox-text">
+                  Confirm delegation to the above address. You can revoke this
+                  at any time from your profile.
+                </span>
+              </label>
+            </div>
+          </div>
+
+          {/* SUBMIT */}
+          <button
+            aria-label={isInProcess ? 'Updating your delegate key...' : ''}
+            className="button"
+            disabled={isInProcessOrDone || isFormFieldEmpty}
+            onClick={async () => {
+              if (isInProcessOrDone) return;
+
+              if (!(await trigger())) {
+                return;
+              }
+
+              handleConfirmDelegation(getValues());
+            }}
+            type="submit">
+            {isInProcess ? <Loader /> : isDone ? 'Done' : 'Confirm'}
+          </button>
+
+          {/* SUBMIT STATUS */}
+          {isInProcessOrDone && (
+            <div className="form__submit-status-container">
+              {renderSubmitStatus()}
+            </div>
+          )}
+
+          {/* SUBMIT ERROR */}
+          {delegateError && (
+            <div className="form__submit-error-container">
+              <ErrorMessageWithDetails
+                renderText="Something went wrong with your delegation."
+                error={delegateError}
+              />
+            </div>
+          )}
+        </form>
+      </>
+    );
+  }
+
+  function renderRevokeDelegation() {
+    if (connectedMember) {
+      return (
+        <>
+          {/* TITLE */}
+          <div className="modal__title">Revoke Delegation</div>
+
+          <p>{truncateEthAddress(connectedMember.delegateKey, 7)}</p>
+          <div className="delegation-modal__arrow-down">&darr;</div>
+          <p>
+            <UserSVG />
+            Back to you
+          </p>
+          <div className="delegation-modal__text">
+            You&apos;ll be able to resume voting from your account. You can
+            delegate again at any time from your profile.
+          </div>
+
+          {/* SUBMIT */}
+          <button
+            aria-label={isInProcess ? 'Updating your delegate key...' : ''}
+            className="button"
+            disabled={isInProcessOrDone}
+            onClick={handleRevokeDelegation}>
+            {isInProcess ? <Loader /> : isDone ? 'Done' : 'Confirm'}
+          </button>
+
+          {/* SUBMIT STATUS */}
+          {isInProcessOrDone && (
+            <div className="form__submit-status-container">
+              {renderSubmitStatus()}
+            </div>
+          )}
+
+          {/* SUBMIT ERROR */}
+          {delegateError && (
+            <div className="form__submit-error-container">
+              <ErrorMessageWithDetails
+                renderText="Something went wrong with your revocation."
+                error={delegateError}
+              />
+            </div>
+          )}
+        </>
+      );
+    }
+
+    return <></>;
+  }
+
+  async function handleConfirmDelegation(values: FormInputs) {
+    try {
+      if (!daoRegistryContract) {
+        throw new Error('No DAO Registry contract was found.');
+      }
+
+      if (!daoRegistryAdapterContract) {
+        throw new Error('No DAO Registry Adapter contract was found.');
+      }
+
+      if (!account) {
+        throw new Error('No account found.');
+      }
+
+      if (!web3Instance) {
+        throw new Error('No Web3 instance was found.');
+      }
+
+      const {delegateAddress} = values;
+
+      const updateDelegateKeyArguments: UpdateDelegateKeyArguments = [
+        daoRegistryContract.contractAddress,
+        toChecksumAddress(delegateAddress),
+      ];
+
+      const txArguments = {
+        from: account || '',
+        // Set a fast gas price
+        ...(gasPrices ? {gasPrice: gasPrices.fast} : null),
+      };
+
+      // Execute contract call for `updateDelegateKey`
+      const tx = await txSend(
+        'updateDelegateKey',
+        daoRegistryAdapterContract.instance.methods,
+        updateDelegateKeyArguments,
+        txArguments
+      );
+
+      if (tx) {
+        setTimeout(async () => {
+          // re-fetch member
+          await dispatch(
+            getConnectedMember({account, daoRegistryContract, web3Instance})
+          );
+
+          closeHandler();
+        }, 2000);
+      }
+    } catch (error) {
+      console.log(error);
+      let parsedError = error;
+
+      if (
+        error.message.includes('cannot overwrite existing delegated keys') ||
+        error.message.includes('address already taken as delegated key')
+      ) {
+        parsedError = new Error(
+          'The provided address cannot be another member or already in use as a delegate.'
+        );
+      }
+
+      setSubmitError(parsedError);
+    }
+  }
+
+  async function handleRevokeDelegation() {
+    try {
+      if (!daoRegistryContract) {
+        throw new Error('No DAO Registry contract was found.');
+      }
+
+      if (!daoRegistryAdapterContract) {
+        throw new Error('No DAO Registry Adapter contract was found.');
+      }
+
+      if (!account) {
+        throw new Error('No account found.');
+      }
+
+      if (!web3Instance) {
+        throw new Error('No Web3 instance was found.');
+      }
+
+      const updateDelegateKeyArguments: UpdateDelegateKeyArguments = [
+        daoRegistryContract.contractAddress,
+        toChecksumAddress(account),
+      ];
+
+      const txArguments = {
+        from: account || '',
+        // Set a fast gas price
+        ...(gasPrices ? {gasPrice: gasPrices.fast} : null),
+      };
+
+      // Execute contract call for `updateDelegateKey`
+      const tx = await txSend(
+        'updateDelegateKey',
+        daoRegistryAdapterContract.instance.methods,
+        updateDelegateKeyArguments,
+        txArguments
+      );
+
+      if (tx) {
+        setTimeout(async () => {
+          // re-fetch member
+          await dispatch(
+            getConnectedMember({account, daoRegistryContract, web3Instance})
+          );
+
+          closeHandler();
+        }, 2000);
+      }
+    } catch (error) {
+      console.log(error);
+
+      setSubmitError(error);
+    }
+  }
+
+  function renderSubmitStatus(): React.ReactNode {
+    switch (txStatus) {
+      case Web3TxStatus.AWAITING_CONFIRM:
+        return 'Awaiting your confirmation\u2026';
+      case Web3TxStatus.PENDING:
+        return (
+          <>
+            <CycleMessage
+              intervalMs={2000}
+              messages={TX_CYCLE_MESSAGES}
+              useFirstItemStart
+              render={(message) => {
+                return <FadeIn key={message}>{message}</FadeIn>;
+              }}
+            />
+
+            <EtherscanURL url={txEtherscanURL} isPending />
+          </>
+        );
+      case Web3TxStatus.FULFILLED:
+        return (
+          <>
+            <div>Submitted!</div>
+
+            <EtherscanURL url={txEtherscanURL} />
+          </>
+        );
+      default:
+        return null;
+    }
+  }
+
+  /**
+   * Render
+   */
+
+  return (
+    <Modal
+      keyProp="delegation"
+      isOpen={isOpen}
+      // Require user to click on close button to avoid accidental modal close
+      // during transaction
+      isOpenHandler={() => {}}
+      modalClassNames="delegation-modal">
+      {/* MODEL CLOSE BUTTON */}
+      <span
+        className="modal__close-button"
+        onClick={() => {
+          closeHandler();
+        }}>
+        <TimesSVG />
+      </span>
+      {renderCurrentStep()}
+    </Modal>
+  );
+}
+
+export default function Delegation() {
+  /**
+   * Selectors
+   */
+
+  const connectedMember = useSelector((s: StoreState) => s.connectedMember);
+
+  /**
+   * State
+   */
+
+  const [currentStep, setCurrentStep] = useState<string>(
+    DelegationStep.SET_DELEGATION
+  );
+  const [delegationStatus, setDelegationStatus] = useState<string>('');
+  const [showDelegationModal, setShowDelegationModal] =
+    useState<boolean>(false);
+
+  /**
+   * Cached callbacks
+   */
+
+  const fetchDelegationInfoCached = useCallback(fetchDelegationInfo, [
+    connectedMember,
+  ]);
+
+  /**
+   * Effects
+   */
+
+  useEffect(() => {
+    fetchDelegationInfoCached();
+  }, [fetchDelegationInfoCached]);
+
+  /**
+   * Functions
+   */
+
+  async function fetchDelegationInfo() {
+    try {
+      if (!connectedMember) {
+        throw new Error('No connected account found.');
+      }
+
+      const currentStep = connectedMember.isAddressDelegated
+        ? DelegationStep.REVOKE_DELEGATION
+        : DelegationStep.SET_DELEGATION;
+      setCurrentStep(currentStep);
+
+      const delegationStatus = connectedMember.isAddressDelegated
+        ? DelegationStatus.REVOKE_DELEGATION
+        : DelegationStatus.DELEGATE_VOTES;
+      setDelegationStatus(delegationStatus);
+    } catch (error) {
+      console.log(error);
+    }
+  }
+
+  /**
+   * Render
+   */
+
+  if (connectedMember) {
+    return (
+      <>
+        {delegationStatus !== '' && (
+          <>
+            <div className="memberprofile__action-description">
+              {connectedMember.isAddressDelegated ? (
+                // CURRENT DELEGATION
+                <>
+                  Your voting rights have been delegated to{' '}
+                  <span className="delegation__delegate-address-text">
+                    {truncateEthAddress(connectedMember.delegateKey, 7)}
+                  </span>
+                  . You can revoke this at any time.
+                </>
+              ) : (
+                <>
+                  You can delegate your voting rights to a different ETH
+                  address. The address cannot be another member or already in
+                  use as a delegate.
+                </>
+              )}
+            </div>
+
+            {/* OPEN DELEGATION MODAL BUTTON */}
+            <button
+              className="memberprofile__action-button"
+              onClick={() => setShowDelegationModal(true)}>
+              {delegationStatus}
+            </button>
+          </>
+        )}
+
+        {showDelegationModal && (
+          <DelegationModal
+            isOpen={showDelegationModal}
+            closeHandler={() => {
+              setShowDelegationModal(false);
+            }}
+            currentStep={currentStep}
+          />
+        )}
+      </>
+    );
+  }
+
+  return <></>;
+}

--- a/src/pages/members/MemberCard.tsx
+++ b/src/pages/members/MemberCard.tsx
@@ -1,6 +1,7 @@
 import {Member} from './types';
 
 import {truncateEthAddress} from '../../util/helpers';
+import {useWeb3Modal} from '../../components/web3/hooks';
 
 type MemberCardProps = {
   member: Member;
@@ -17,6 +18,12 @@ export default function MemberCard(props: MemberCardProps): JSX.Element {
   const {member, onClick} = props;
 
   /**
+   * Our hooks
+   */
+
+  const {account} = useWeb3Modal();
+
+  /**
    * Functions
    */
 
@@ -31,7 +38,13 @@ export default function MemberCard(props: MemberCardProps): JSX.Element {
    */
 
   return (
-    <div className="membercard" onClick={handleClick}>
+    <div
+      className={`membercard ${
+        account && account.toLowerCase() === member.address.toLowerCase()
+          ? `membercard--connected-account`
+          : ''
+      }`}
+      onClick={handleClick}>
       {/* TITLE */}
       <h3 className="membercard__title">
         {truncateEthAddress(member.address, 7)}

--- a/src/pages/members/MemberProfile.tsx
+++ b/src/pages/members/MemberProfile.tsx
@@ -109,6 +109,7 @@ export default function MemberProfile() {
         </div>
         <div className="memberprofile__info-item">
           <span>Voting Weight</span>
+          <span>TODO%</span>
         </div>
       </div>
     );

--- a/src/pages/members/MemberProfile.tsx
+++ b/src/pages/members/MemberProfile.tsx
@@ -124,17 +124,23 @@ export default function MemberProfile() {
   }
 
   function renderMemberActions() {
-    return (
-      <div>
-        <div className="memberprofile__action">
-          <div className="memberprofile__action-header">Delegation</div>
-          <div className="memberprofile__action-description">
-            You can delegate your voting rights to a different ETH address.
+    if (isCurrentMemberConnected) {
+      return (
+        <div>
+          <div className="memberprofile__action">
+            <div className="memberprofile__action-header">Delegation</div>
+            <Delegation />
           </div>
-          <Delegation />
         </div>
-      </div>
-    );
+      );
+    } else {
+      return (
+        <div className="memberprofile__actions-unavailable">
+          Connect your wallet with this member address to view available
+          actions.
+        </div>
+      );
+    }
   }
 
   /**

--- a/src/pages/members/hooks/useMembers.ts
+++ b/src/pages/members/hooks/useMembers.ts
@@ -1,8 +1,7 @@
-import {AbiItem, toBN} from 'web3-utils';
 import {useCallback, useEffect, useState} from 'react';
 import {useLazyQuery} from '@apollo/react-hooks';
 import {useSelector} from 'react-redux';
-import Web3 from 'web3';
+import {AbiItem, toBN, toChecksumAddress} from 'web3-utils';
 
 import {AsyncStatus} from '../../../util/types';
 import {GET_MEMBERS} from '../../../gql';
@@ -23,7 +22,7 @@ type UseMembersReturn = {
 /**
  * useMembers
  *
- * @returns `UseMembersReturn` An object with the members, and the current async status.
+ * @returns {UseMembersReturn} An object with the members, and the current async status.
  */
 export default function useMembers(): UseMembersReturn {
   /**
@@ -144,8 +143,8 @@ export default function useMembers(): UseMembersReturn {
             return {
               ...parsedMember,
               // use formatted addresses
-              address: Web3.utils.toChecksumAddress(member.address),
-              delegateKey: Web3.utils.toChecksumAddress(member.delegateKey),
+              address: toChecksumAddress(member.address),
+              delegateKey: toChecksumAddress(member.delegateKey),
             };
           }
         );

--- a/src/pages/members/hooks/useMembers.ts
+++ b/src/pages/members/hooks/useMembers.ts
@@ -22,7 +22,7 @@ type UseMembersReturn = {
 /**
  * useMembers
  *
- * @returns {UseMembersReturn} An object with the members, and the current async status.
+ * @returns {UseMembersReturn} An object with the members and the current async status.
  */
 export default function useMembers(): UseMembersReturn {
   /**
@@ -64,11 +64,9 @@ export default function useMembers(): UseMembersReturn {
    */
 
   const [members, setMembers] = useState<Member[]>([]);
-
   const [membersStatus, setMembersStatus] = useState<AsyncStatus>(
     AsyncStatus.STANDBY
   );
-
   const [membersError, setMembersError] = useState<Error>();
 
   /**

--- a/src/pages/members/hooks/useMembers.ts
+++ b/src/pages/members/hooks/useMembers.ts
@@ -22,6 +22,8 @@ type UseMembersReturn = {
 /**
  * useMembers
  *
+ * Gets DAO members from subgraph with direct onchain fallback.
+ *
  * @returns {UseMembersReturn} An object with the members and the current async status.
  */
 export default function useMembers(): UseMembersReturn {

--- a/src/pages/membership/CreateMembershipProposal.tsx
+++ b/src/pages/membership/CreateMembershipProposal.tsx
@@ -12,14 +12,13 @@ import {
   truncateEthAddress,
   normalizeString,
 } from '../../util/helpers';
-import {useIsDefaultChain} from '../../components/web3/hooks';
+import {useIsDefaultChain, useWeb3Modal} from '../../components/web3/hooks';
 import {ContractAdapterNames, Web3TxStatus} from '../../components/web3/types';
 import {FormFieldErrors} from '../../util/enums';
 import {isEthAddressValid} from '../../util/validation';
 import {UNITS_ADDRESS} from '../../config';
 import {CycleEllipsis} from '../../components/feedback';
 import {useSignAndSubmitProposal} from '../../components/proposals/hooks';
-import {useWeb3Modal} from '../../components/web3/hooks';
 import ErrorMessageWithDetails from '../../components/common/ErrorMessageWithDetails';
 import FadeIn from '../../components/common/FadeIn';
 import InputError from '../../components/common/InputError';

--- a/src/pages/redeem/RedeemManager.tsx
+++ b/src/pages/redeem/RedeemManager.tsx
@@ -16,17 +16,17 @@ import {TX_CYCLE_MESSAGES} from '../../components/web3/config';
 
 type RedeemManagerProps = {
   redeemables: Record<string, any>;
-  erc20Details?: ERC20RegisterDetails;
+  daoTokenDetails?: ERC20RegisterDetails;
 };
 
 type RedeemCardProps = {
   redeemable: Record<string, any>;
-  erc20Details?: ERC20RegisterDetails;
+  daoTokenDetails?: ERC20RegisterDetails;
 };
 
 export default function RedeemManager({
   redeemables,
-  erc20Details,
+  daoTokenDetails,
 }: RedeemManagerProps) {
   /**
    *  RENDER
@@ -35,12 +35,15 @@ export default function RedeemManager({
   // show the redeem card, if only one coupon available
   return (
     <RenderWrapper>
-      <RedeemCard redeemable={redeemables[0]} erc20Details={erc20Details} />
+      <RedeemCard
+        redeemable={redeemables[0]}
+        daoTokenDetails={daoTokenDetails}
+      />
     </RenderWrapper>
   );
 }
 
-function RedeemCard({redeemable, erc20Details}: RedeemCardProps) {
+function RedeemCard({redeemable, daoTokenDetails}: RedeemCardProps) {
   /**
    * Our hooks
    */
@@ -126,11 +129,11 @@ function RedeemCard({redeemable, erc20Details}: RedeemCardProps) {
       <p className="redeemcard__unit">
         {formatNumber(redeemable.amount)}
         <sup>
-          <small>{erc20Details?.symbol || 'tokens'}</small>
+          <small>{daoTokenDetails?.symbol || 'tokens'}</small>
         </sup>
       </p>
 
-      <DaoToken erc20Details={erc20Details} />
+      <DaoToken daoTokenDetails={daoTokenDetails} />
 
       {isDone && (
         <p className="redeemcard__redeemed">
@@ -148,7 +151,7 @@ function RedeemCard({redeemable, erc20Details}: RedeemCardProps) {
         className="button"
         style={{marginTop: isDone ? '1rem' : '1.5rem'}}
         onClick={async () => {
-          await redeemCoupon(redeemable, erc20Details);
+          await redeemCoupon(redeemable, daoTokenDetails);
         }}
         disabled={isInProcessOrDone}>
         {isInProcess ? <Loader /> : isDone ? 'Redeemed!' : 'Redeem'}

--- a/src/pages/transfers/CreateTransferProposal.tsx
+++ b/src/pages/transfers/CreateTransferProposal.tsx
@@ -21,6 +21,7 @@ import {
   useContractSend,
   useETHGasPrice,
   useIsDefaultChain,
+  useWeb3Modal,
 } from '../../components/web3/hooks';
 import {ContractAdapterNames, Web3TxStatus} from '../../components/web3/types';
 import {FormFieldErrors} from '../../util/enums';
@@ -30,7 +31,6 @@ import {StoreState} from '../../store/types';
 import {TX_CYCLE_MESSAGES} from '../../components/web3/config';
 import {multicall, MulticallTuple} from '../../components/web3/helpers';
 import {useSignAndSubmitProposal} from '../../components/proposals/hooks';
-import {useWeb3Modal} from '../../components/web3/hooks';
 import CycleMessage from '../../components/feedback/CycleMessage';
 import ErrorMessageWithDetails from '../../components/common/ErrorMessageWithDetails';
 import FadeIn from '../../components/common/FadeIn';

--- a/src/pages/tributes/CreateTributeProposal.tsx
+++ b/src/pages/tributes/CreateTributeProposal.tsx
@@ -14,14 +14,13 @@ import {
   normalizeString,
   truncateEthAddress,
 } from '../../util/helpers';
-import {useIsDefaultChain} from '../../components/web3/hooks';
+import {useIsDefaultChain, useWeb3Modal} from '../../components/web3/hooks';
 import {ContractAdapterNames, Web3TxStatus} from '../../components/web3/types';
 import {FormFieldErrors} from '../../util/enums';
 import {isEthAddressValid} from '../../util/validation';
 import {UNITS_ADDRESS} from '../../config';
 import {StoreState} from '../../store/types';
 import {useSignAndSubmitProposal} from '../../components/proposals/hooks';
-import {useWeb3Modal} from '../../components/web3/hooks';
 import {CycleEllipsis} from '../../components/feedback';
 import ErrorMessageWithDetails from '../../components/common/ErrorMessageWithDetails';
 import FadeIn from '../../components/common/FadeIn';


### PR DESCRIPTION
Fixes #176, Fixes #377

🥳 **Adds**

 - Member profile page for current active members. Each page includes (1) number of owned units/tokens (also includes DAO token widget with buttons to copy token address and add token to wallet if (a) the DAO has an ERC20Extension and (b) the connected user is the member), (2) voting weight, and (3) delegation action (which is only available if connected user is the member).
 - Delegation feature is available to connected member user to (1) delegate voting rights to another address and (2) revoke such delegation.
 - `useDaoTotalUnits` hook to get DAO `totalUnits` through the subgraph with fallback to fetching value directly from smart contract.
 - `useDaoTokenDetails` replaces duplicate code in several components to get ERC20Extension token details.

✨ **Updates**

 - `DaoTokenHolder` component has been updated to check connected account against member address (not delegate key)
 - Profile link in nav menu is shown only if connected user is a member (not a delegate) because a profile page only exists for a member account.

🧹 **Chores done**
 
 - General cleanup to files (e.g., consolidating imports at top of files and naming conventions).
 - Moves `useTokenHolderBalances` hook and test with related files in `src/components/dao-token/hooks`.
