### PR TITLE
move dev site to `demo` subdomain

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -53,4 +53,4 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./build
           commit_message: ${{ github.event.head_commit.message }}
-          cname: tributedao.com
+          cname: demo.tributedao.com

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Follow the instructions [here](https://github.com/openlawteam/tribute-contracts/
 
 Deployments for the development environment are handled automatically with a GitHub Action:
 
-- `GitHub Pages development deployment`: push to `main` branch -> https://tributedao.com
+- `GitHub Pages development deployment`: push to `main` branch -> https://demo.tributedao.com
 
 ## Developer notes
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "type": "git",
     "url": "https://github.com/openlawteam/tribute-ui.git"
   },
-  "homepage": "https://tributedao.com",
+  "homepage": "https://demo.tributedao.com",
   "author": "OpenLaw Team",
   "license": "Apache-2.0",
   "description": "A modular DAO framework developed and coordinated by its members",

--- a/public/CNAME
+++ b/public/CNAME
@@ -1,1 +1,1 @@
-tributedao.com
+demo.tributedao.com


### PR DESCRIPTION
✨ **Updates**

 - Move development site to subdomain `demo.tributedao.com` (so new docs site can use `tributedao.com`)
 
