### PR TITLE
updates `@openlaw/snapshot-js-erc712` to `1.1.2`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@apollo/client": "^3.3.17",
         "@apollo/react-hooks": "^4.0.0",
-        "@openlaw/snapshot-js-erc712": "^1.1.1",
+        "@openlaw/snapshot-js-erc712": "^1.1.2",
         "@walletconnect/web3-provider": "^1.3.2",
         "aos": "^2.3.4",
         "ethers": "^5.4.0",
@@ -2951,9 +2951,9 @@
       "dev": true
     },
     "node_modules/@openlaw/snapshot-js-erc712": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@openlaw/snapshot-js-erc712/-/snapshot-js-erc712-1.1.1.tgz",
-      "integrity": "sha512-amROkn7TAmCltvjt+j2dKpY9/ynhnsbKgCHvyLUj9WhfFSJlT1QGA888PAKLBbKv7xnHYkH6adHVb7EX4VDQrg==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@openlaw/snapshot-js-erc712/-/snapshot-js-erc712-1.1.2.tgz",
+      "integrity": "sha512-yvN/Yc2OBsRWWgC+MrewIAW/oOFv0wXEyr+iwopwy7qciJqfLU4XJzVCCzashbRBsVl36Fv4FJWrxArteRCOqg==",
       "dependencies": {
         "axios": "^0.21.1",
         "eth-sig-util": "^3.0.1",
@@ -30881,9 +30881,9 @@
       "dev": true
     },
     "@openlaw/snapshot-js-erc712": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@openlaw/snapshot-js-erc712/-/snapshot-js-erc712-1.1.1.tgz",
-      "integrity": "sha512-amROkn7TAmCltvjt+j2dKpY9/ynhnsbKgCHvyLUj9WhfFSJlT1QGA888PAKLBbKv7xnHYkH6adHVb7EX4VDQrg==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@openlaw/snapshot-js-erc712/-/snapshot-js-erc712-1.1.2.tgz",
+      "integrity": "sha512-yvN/Yc2OBsRWWgC+MrewIAW/oOFv0wXEyr+iwopwy7qciJqfLU4XJzVCCzashbRBsVl36Fv4FJWrxArteRCOqg==",
       "requires": {
         "axios": "^0.21.1",
         "eth-sig-util": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@apollo/client": "^3.3.17",
     "@apollo/react-hooks": "^4.0.0",
-    "@openlaw/snapshot-js-erc712": "^1.1.1",
+    "@openlaw/snapshot-js-erc712": "^1.1.2",
     "@walletconnect/web3-provider": "^1.3.2",
     "aos": "^2.3.4",
     "ethers": "^5.4.0",


### PR DESCRIPTION

✨ **Updates**

 - `@openlaw/snapshot-js-erc712` to `1.1.2`. Fixes a bug where no `weight` for a vote was setting `choice: 0`. Reference: https://github.com/openlawteam/snapshot-js-erc712/pull/31
 