### PR TITLE
suggest adding token to wallet only if relevant to connected account

### DIFF
--- a/src/components/proposals/ProcessActionMembership.tsx
+++ b/src/components/proposals/ProcessActionMembership.tsx
@@ -225,8 +225,14 @@ export default function ProcessActionMembership(
           })
         );
 
-        // suggest adding DAO token to wallet
-        await addTokenToWallet();
+        // if connected account is the applicant (the address that will receive
+        // the membership units) suggest adding DAO token to wallet
+        if (
+          account.toLowerCase() ===
+          snapshotProposal.msg.payload.metadata.submitActionArgs[0].toLowerCase()
+        ) {
+          await addTokenToWallet();
+        }
       }
     } catch (error) {
       setSubmitError(error);

--- a/src/components/proposals/ProcessActionTribute.tsx
+++ b/src/components/proposals/ProcessActionTribute.tsx
@@ -313,8 +313,14 @@ export default function ProcessActionTribute(props: ProcessActionTributeProps) {
           })
         );
 
-        // suggest adding DAO token to wallet
-        await addTokenToWallet();
+        // if connected account is the applicant (the address that will receive
+        // the membership units) suggest adding DAO token to wallet
+        if (
+          account.toLowerCase() ===
+          snapshotProposal.msg.payload.metadata.submitActionArgs[0].toLowerCase()
+        ) {
+          await addTokenToWallet();
+        }
       }
     } catch (error) {
       setSubmitError(error);


### PR DESCRIPTION
✨ **Updates**

 - When a proposal that involves issuing membership units is processed, the connected account receives a prompt to add the DAO token to their wallet. But this is only relevant if the connected account (who was the original proposer) is the applicant account. If the connected account/original proposer submitted on behalf of a different applicant account, then there is no need to suggest adding the token to their wallet because those tokens are issued to the applicant account instead.
 
