### PR TITLE
Cleans up `FakeHttpProvider` and provides a debug method

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -50,7 +50,6 @@
         "@types/react-router": "^5.1.16",
         "@types/react-router-dom": "^5.1.7",
         "@types/react-transition-group": "^4.4.1",
-        "abi-decoder": "^2.4.0",
         "dotenv": "^10.0.0",
         "http-proxy-middleware": "^2.0.0",
         "msw": "^0.30.1",
@@ -4489,16 +4488,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.5.tgz",
       "integrity": "sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q=="
-    },
-    "node_modules/abi-decoder": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/abi-decoder/-/abi-decoder-2.4.0.tgz",
-      "integrity": "sha512-TOLU2q1HgYOjs1GKGtVzaqrYkar6I2fT9a80rzx6/9EJ/5crb4nCGuro0grZayixem93T7omrajYmLiMkYDLDA==",
-      "dev": true,
-      "dependencies": {
-        "web3-eth-abi": "^1.2.1",
-        "web3-utils": "^1.2.1"
-      }
     },
     "node_modules/abstract-leveldown": {
       "version": "2.6.3",
@@ -32150,16 +32139,6 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.5.tgz",
       "integrity": "sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q=="
-    },
-    "abi-decoder": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/abi-decoder/-/abi-decoder-2.4.0.tgz",
-      "integrity": "sha512-TOLU2q1HgYOjs1GKGtVzaqrYkar6I2fT9a80rzx6/9EJ/5crb4nCGuro0grZayixem93T7omrajYmLiMkYDLDA==",
-      "dev": true,
-      "requires": {
-        "web3-eth-abi": "^1.2.1",
-        "web3-utils": "^1.2.1"
-      }
     },
     "abstract-leveldown": {
       "version": "2.6.3",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,6 @@
     "@types/react-router": "^5.1.16",
     "@types/react-router-dom": "^5.1.7",
     "@types/react-transition-group": "^4.4.1",
-    "abi-decoder": "^2.4.0",
     "dotenv": "^10.0.0",
     "http-proxy-middleware": "^2.0.0",
     "msw": "^0.30.1",

--- a/src/components/governance/GovernanceProposalsList.unit.test.tsx
+++ b/src/components/governance/GovernanceProposalsList.unit.test.tsx
@@ -148,8 +148,7 @@ describe('GovernanceProposalsList unit tests', () => {
             web3Instance.eth.abi.encodeParameter('uint256', '100000'),
           ],
         ]
-      ),
-      {abi: MulticallABI, abiMethodName: 'aggregate'}
+      )
     );
 
     // 2. Inject failed result
@@ -164,8 +163,7 @@ describe('GovernanceProposalsList unit tests', () => {
             web3Instance.eth.abi.encodeParameter('uint256', '300000'),
           ],
         ]
-      ),
-      {abi: MulticallABI, abiMethodName: 'aggregate'}
+      )
     );
 
     // 3. Inject voting result
@@ -180,8 +178,7 @@ describe('GovernanceProposalsList unit tests', () => {
             web3Instance.eth.abi.encodeParameter('uint256', '100000'),
           ],
         ]
-      ),
-      {abi: MulticallABI, abiMethodName: 'aggregate'}
+      )
     );
   };
 

--- a/src/components/proposals/hooks/useCheckApplicant.unit.test.ts
+++ b/src/components/proposals/hooks/useCheckApplicant.unit.test.ts
@@ -1,15 +1,17 @@
 import {act, renderHook} from '@testing-library/react-hooks';
 import {waitFor} from '@testing-library/react';
+import Web3 from 'web3';
 
 import {
   DEFAULT_ETH_ADDRESS,
   DEFAULT_DELEGATED_ADDRESS,
+  FakeHttpProvider,
 } from '../../../test/helpers';
-import Wrapper from '../../../test/Wrapper';
-import {useCheckApplicant} from './useCheckApplicant';
 import {AsyncStatus} from '../../../util/types';
-import {GUILD_ADDRESS} from '../../../config';
 import {BURN_ADDRESS} from '../../../util/constants';
+import {GUILD_ADDRESS} from '../../../config';
+import {useCheckApplicant} from './useCheckApplicant';
+import Wrapper from '../../../test/Wrapper';
 
 describe('useCheckApplicant unit tests', () => {
   test('should return correct data when applicant address is undefined', async () => {
@@ -36,8 +38,8 @@ describe('useCheckApplicant unit tests', () => {
 
   test('should return correct data when applicant address is valid', async () => {
     await act(async () => {
-      let mockWeb3Provider: any;
-      let web3Instance: any;
+      let mockWeb3Provider: FakeHttpProvider;
+      let web3Instance: Web3;
 
       const address = DEFAULT_ETH_ADDRESS;
 
@@ -87,8 +89,8 @@ describe('useCheckApplicant unit tests', () => {
 
   test('should return correct data when applicant address is reserved', async () => {
     await act(async () => {
-      let mockWeb3Provider: any;
-      let web3Instance: any;
+      let mockWeb3Provider: FakeHttpProvider;
+      let web3Instance: Web3;
 
       const address = GUILD_ADDRESS;
 
@@ -137,8 +139,8 @@ describe('useCheckApplicant unit tests', () => {
 
   test('should return correct data when applicant address is address(0x0)', async () => {
     await act(async () => {
-      let mockWeb3Provider: any;
-      let web3Instance: any;
+      let mockWeb3Provider: FakeHttpProvider;
+      let web3Instance: Web3;
 
       const address = BURN_ADDRESS;
 
@@ -187,8 +189,8 @@ describe('useCheckApplicant unit tests', () => {
 
   test('should return correct data when applicant address is already used as delegate key', async () => {
     await act(async () => {
-      let mockWeb3Provider: any;
-      let web3Instance: any;
+      let mockWeb3Provider: FakeHttpProvider;
+      let web3Instance: Web3;
 
       const address = DEFAULT_ETH_ADDRESS;
 

--- a/src/components/proposals/hooks/useOffchainVotingResults.unit.test.ts
+++ b/src/components/proposals/hooks/useOffchainVotingResults.unit.test.ts
@@ -141,8 +141,7 @@ describe('useOffchainVotingResults unit tests', () => {
               web3Instance.eth.abi.encodeParameter('uint256', '100000'),
             ],
           ]
-        ),
-        {abi: MulticallABI, abiMethodName: 'aggregate'}
+        )
       );
 
       // Inject mocked units result 2
@@ -157,8 +156,7 @@ describe('useOffchainVotingResults unit tests', () => {
               web3Instance.eth.abi.encodeParameter('uint256', '200000'),
             ],
           ]
-        ),
-        {abi: MulticallABI, abiMethodName: 'aggregate'}
+        )
       );
 
       await waitForValueToChange(

--- a/src/components/proposals/voting/OffchainOpRollupVotingSubmitResultAction.unit.test.tsx
+++ b/src/components/proposals/voting/OffchainOpRollupVotingSubmitResultAction.unit.test.tsx
@@ -241,19 +241,18 @@ describe('OffchainOpRollupVotingSubmitResultAction unit tests', () => {
       ).toBeInTheDocument();
     });
 
-    await waitFor(() => {
-      // The component start `useFirstItemStart = true` for `<CycleMessage />`
-      expect(screen.getByText(TX_CYCLE_MESSAGES[0])).toBeInTheDocument();
-      expect(screen.getByText(/view progress/i)).toBeInTheDocument();
-    });
-
     // Mock RPC calls for `submitVoteResult`
     await waitFor(() => {
-      // Mock RPC calls for estimating gas before the tx
       mockWeb3Provider.injectResult(...ethEstimateGas({web3Instance}));
       mockWeb3Provider.injectResult(...ethGasPrice({web3Instance}));
       mockWeb3Provider.injectResult(...sendTransaction({web3Instance}));
       mockWeb3Provider.injectResult(...getTransactionReceipt({web3Instance}));
+    });
+
+    await waitFor(() => {
+      // The component start `useFirstItemStart = true` for `<CycleMessage />`
+      expect(screen.getByText(TX_CYCLE_MESSAGES[0])).toBeInTheDocument();
+      expect(screen.getByText(/view progress/i)).toBeInTheDocument();
     });
 
     await waitFor(() => {
@@ -331,19 +330,18 @@ describe('OffchainOpRollupVotingSubmitResultAction unit tests', () => {
       ).toBeInTheDocument();
     });
 
-    await waitFor(() => {
-      // The component start `useFirstItemStart = true` for `<CycleMessage />`
-      expect(screen.getByText(TX_CYCLE_MESSAGES[0])).toBeInTheDocument();
-      expect(screen.getByText(/view progress/i)).toBeInTheDocument();
-    });
-
     // Mock RPC calls for `submitVoteResult`
     await waitFor(() => {
-      // Mock RPC calls for estimating gas before the tx
       mockWeb3Provider.injectResult(...ethEstimateGas({web3Instance}));
       mockWeb3Provider.injectResult(...ethGasPrice({web3Instance}));
       mockWeb3Provider.injectResult(...sendTransaction({web3Instance}));
       mockWeb3Provider.injectResult(...getTransactionReceipt({web3Instance}));
+    });
+
+    await waitFor(() => {
+      // The component start `useFirstItemStart = true` for `<CycleMessage />`
+      expect(screen.getByText(TX_CYCLE_MESSAGES[0])).toBeInTheDocument();
+      expect(screen.getByText(/view progress/i)).toBeInTheDocument();
     });
 
     await waitFor(() => {

--- a/src/hooks/useRedeemCoupon.unit.test.ts
+++ b/src/hooks/useRedeemCoupon.unit.test.ts
@@ -1,16 +1,19 @@
 import {renderHook, act} from '@testing-library/react-hooks';
+import {waitFor} from '@testing-library/react';
 import Web3 from 'web3';
 
-import {useRedeemCoupon, FetchStatus} from '.';
-import {Web3TxStatus} from '../components/web3/types';
-import {DEFAULT_ETH_ADDRESS, FakeHttpProvider} from '../test/helpers';
-import Wrapper from '../test/Wrapper';
 import {
   ethEstimateGas,
   ethGasPrice,
   getTransactionReceipt,
   sendTransaction,
 } from '../test/web3Responses';
+import {COUPON_API_URL} from '../config';
+import {DEFAULT_ETH_ADDRESS, FakeHttpProvider} from '../test/helpers';
+import {rest, server} from '../test/server';
+import {useRedeemCoupon, FetchStatus} from '.';
+import {Web3TxStatus} from '../components/web3/types';
+import Wrapper from '../test/Wrapper';
 
 describe('useRedeemCoupon unit tests', () => {
   test('should return correct data when wallet is disconnected', async () => {
@@ -33,71 +36,229 @@ describe('useRedeemCoupon unit tests', () => {
   });
 
   test('should throw rejection when coupon data is empty', async () => {
-    const {result, waitForNextUpdate, waitForValueToChange} = renderHook(
-      () => useRedeemCoupon(),
-      {
-        initialProps: {
-          useInit: true,
-          useWallet: true,
-        },
-        wrapper: Wrapper,
-      }
-    );
-
-    // Assert initial state
-    expect(result.current.isInProcessOrDone).toBe(false);
-    expect(result.current.redeemCoupon).toBeInstanceOf(Function);
-    expect(result.current.submitStatus).toMatch(FetchStatus.STANDBY);
-    expect(result.current.submitError).toBe(undefined);
-    expect(result.current.txStatus).toBe(Web3TxStatus.STANDBY);
-    expect(result.current.txError).toBe(undefined);
-    expect(result.current.txEtherscanURL).toBe('');
-    expect(result.current.txIsPromptOpen).toBe(false);
-
-    // wait for DaoRegistry & CouponOnboarding contracts from store
-    await waitForNextUpdate();
-
-    act(() => {
-      result.current.redeemCoupon({});
-    });
-
-    await waitForValueToChange(() => result.current.submitStatus);
-
-    expect(result.current.submitStatus).toMatch(FetchStatus.REJECTED);
-  });
-
-  test('should redeem coupon', async () => {
     let mockWeb3Provider: FakeHttpProvider;
     let web3Instance: Web3;
 
-    const {result, waitForNextUpdate, waitForValueToChange} = renderHook(
-      () => useRedeemCoupon(),
-      {
-        initialProps: {
-          useInit: true,
-          useWallet: true,
-          getProps: (p) => {
-            mockWeb3Provider = p.mockWeb3Provider;
-            web3Instance = p.web3Instance;
+    await act(async () => {
+      const {result, waitForNextUpdate, waitForValueToChange} =
+        await renderHook(() => useRedeemCoupon(), {
+          initialProps: {
+            useInit: true,
+            useWallet: true,
+            getProps: (p) => {
+              mockWeb3Provider = p.mockWeb3Provider;
+              web3Instance = p.web3Instance;
+            },
           },
-        },
+          wrapper: Wrapper,
+        });
 
-        wrapper: Wrapper,
-      }
+      // Assert initial state
+      expect(result.current.isInProcessOrDone).toBe(false);
+      expect(result.current.redeemCoupon).toBeInstanceOf(Function);
+      expect(result.current.submitStatus).toMatch(FetchStatus.STANDBY);
+      expect(result.current.submitError).toBe(undefined);
+      expect(result.current.txStatus).toBe(Web3TxStatus.STANDBY);
+      expect(result.current.txError).toBe(undefined);
+      expect(result.current.txEtherscanURL).toBe('');
+      expect(result.current.txIsPromptOpen).toBe(false);
+
+      // wait for DaoRegistry & CouponOnboarding contracts from store
+      await waitForNextUpdate();
+      await waitForNextUpdate();
+
+      act(() => {
+        mockWeb3Provider.injectResult(...ethEstimateGas({web3Instance}));
+        mockWeb3Provider.injectResult(...ethGasPrice({web3Instance}));
+        mockWeb3Provider.injectResult(...sendTransaction({web3Instance}));
+        mockWeb3Provider.injectResult(...getTransactionReceipt({web3Instance}));
+
+        // Run redeem coupon without the proper arguments
+        result.current.redeemCoupon({});
+      });
+
+      await waitForValueToChange(() => result.current.submitStatus);
+
+      expect(result.current.submitStatus).toMatch(FetchStatus.REJECTED);
+    });
+  });
+
+  test('should redeem coupon', async () => {
+    const redeemableCoupon = {
+      recipient: DEFAULT_ETH_ADDRESS,
+      signature:
+        '0x75508974ae5ac12d67e60d5758499e7c4811a2e7c5f50281745b7eaffc695d374ad5b537d877e589c10b0971f25193ad99b51c759b0432fbd1932be5fb118fb51c',
+      nonce: 1,
+      amount: 10000,
+      dao: {daoAddress: '0x7BBAfD0edD40AeFAb0e93816DB5154E98f618103'},
+    };
+
+    let mockWeb3Provider: FakeHttpProvider;
+    let web3Instance: Web3;
+
+    await act(async () => {
+      const {result, waitForNextUpdate, waitForValueToChange} =
+        await renderHook(() => useRedeemCoupon(), {
+          initialProps: {
+            useInit: true,
+            useWallet: true,
+            getProps: (p) => {
+              mockWeb3Provider = p.mockWeb3Provider;
+              web3Instance = p.web3Instance;
+            },
+          },
+
+          wrapper: Wrapper,
+        });
+
+      // Assert initial state
+      expect(result.current.isInProcessOrDone).toBe(false);
+      expect(result.current.redeemCoupon).toBeInstanceOf(Function);
+      expect(result.current.submitStatus).toMatch(FetchStatus.STANDBY);
+      expect(result.current.submitError).toBe(undefined);
+      expect(result.current.txStatus).toBe(Web3TxStatus.STANDBY);
+      expect(result.current.txError).toBe(undefined);
+      expect(result.current.txEtherscanURL).toBe('');
+      expect(result.current.txIsPromptOpen).toBe(false);
+
+      // wait for DaoRegistry & CouponOnboarding contracts from store
+      await waitForNextUpdate();
+      await waitForNextUpdate();
+
+      act(() => {
+        // Mock tx result
+        mockWeb3Provider.injectResult(...ethEstimateGas({web3Instance}));
+        mockWeb3Provider.injectResult(...ethGasPrice({web3Instance}));
+        mockWeb3Provider.injectResult(...sendTransaction({web3Instance}));
+        mockWeb3Provider.injectResult(...getTransactionReceipt({web3Instance}));
+
+        // Run redeem coupon
+        result.current.redeemCoupon(redeemableCoupon);
+      });
+
+      expect(result.current.txStatus).toMatch(Web3TxStatus.AWAITING_CONFIRM);
+      expect(result.current.txIsPromptOpen).toBe(true);
+
+      await waitForValueToChange(() => result.current.txStatus);
+
+      expect(result.current.txStatus).toMatch(Web3TxStatus.PENDING);
+
+      await waitFor(() => {
+        // Mock `getConnectedMember`
+        mockWeb3Provider.injectResult(
+          web3Instance.eth.abi.encodeParameters(
+            ['uint256', 'bytes[]'],
+            [
+              0,
+              [
+                // For `getAddressIfDelegated` call
+                web3Instance.eth.abi.encodeParameter(
+                  'address',
+                  DEFAULT_ETH_ADDRESS
+                ),
+                // For `members` call
+                web3Instance.eth.abi.encodeParameter('uint8', '1'),
+                // For `isActiveMember` call
+                web3Instance.eth.abi.encodeParameter('bool', true),
+                // For `getCurrentDelegateKey` call
+                web3Instance.eth.abi.encodeParameter(
+                  'address',
+                  DEFAULT_ETH_ADDRESS
+                ),
+              ],
+            ]
+          ),
+          {debugName: '`getConnectedMember`'}
+        );
+      });
+
+      await waitFor(() => {
+        expect(result.current.isInProcessOrDone).toBe(true);
+        expect(result.current.submitError).toBe(undefined);
+        expect(result.current.submitStatus).toMatch(FetchStatus.FULFILLED);
+        expect(result.current.txError).toBe(undefined);
+        // No etherscan URL for Ganache
+        expect(result.current.txEtherscanURL).toBe('');
+        expect(result.current.txIsPromptOpen).toBe(false);
+        expect(result.current.txStatus).toMatch(Web3TxStatus.FULFILLED);
+      });
+    });
+  });
+
+  test('should return correct data when tx error', async () => {
+    const redeemableCoupon = {
+      recipient: DEFAULT_ETH_ADDRESS,
+      signature:
+        '0x75508974ae5ac12d67e60d5758499e7c4811a2e7c5f50281745b7eaffc695d374ad5b537d877e589c10b0971f25193ad99b51c759b0432fbd1932be5fb118fb51c',
+      nonce: 1,
+      amount: 10000,
+      dao: {daoAddress: '0x7BBAfD0edD40AeFAb0e93816DB5154E98f618103'},
+    };
+
+    let mockWeb3Provider: FakeHttpProvider;
+
+    await act(async () => {
+      const {result, waitForNextUpdate} = await renderHook(
+        () => useRedeemCoupon(),
+        {
+          initialProps: {
+            useInit: true,
+            useWallet: true,
+            getProps: (p) => {
+              mockWeb3Provider = p.mockWeb3Provider;
+            },
+          },
+
+          wrapper: Wrapper,
+        }
+      );
+
+      // Assert initial state
+      expect(result.current.isInProcessOrDone).toBe(false);
+      expect(result.current.redeemCoupon).toBeInstanceOf(Function);
+      expect(result.current.submitStatus).toMatch(FetchStatus.STANDBY);
+      expect(result.current.submitError).toBe(undefined);
+      expect(result.current.txStatus).toBe(Web3TxStatus.STANDBY);
+      expect(result.current.txError).toBe(undefined);
+      expect(result.current.txEtherscanURL).toBe('');
+      expect(result.current.txIsPromptOpen).toBe(false);
+
+      // wait for DaoRegistry & CouponOnboarding contracts from store
+      await waitForNextUpdate();
+      await waitForNextUpdate();
+
+      act(() => {
+        // Mock tx error
+        mockWeb3Provider.injectError({code: 1234, message: 'Some tx error'});
+
+        // Run redeem coupon
+        result.current.redeemCoupon(redeemableCoupon);
+      });
+
+      expect(result.current.txStatus).toMatch(Web3TxStatus.AWAITING_CONFIRM);
+      expect(result.current.txIsPromptOpen).toBe(true);
+
+      await waitFor(() => {
+        expect(result.current.isInProcessOrDone).toBe(false);
+        expect(result.current.submitError?.message).toMatch(/some tx error/i);
+        expect(result.current.submitStatus).toMatch(FetchStatus.REJECTED);
+        expect(result.current.txError?.message).toMatch(/some tx error/i);
+        // No etherscan URL for Ganache
+        expect(result.current.txEtherscanURL).toBe('');
+        expect(result.current.txIsPromptOpen).toBe(false);
+        expect(result.current.txStatus).toMatch(Web3TxStatus.REJECTED);
+      });
+    });
+  });
+
+  test('should return correct data when server HTTP error', async () => {
+    // Mock HTTP error
+    server.use(
+      rest.patch(
+        `${COUPON_API_URL}/api/coupon/redeem`,
+        async (_req, res, ctx) => res(ctx.status(500))
+      )
     );
-
-    // Assert initial state
-    expect(result.current.isInProcessOrDone).toBe(false);
-    expect(result.current.redeemCoupon).toBeInstanceOf(Function);
-    expect(result.current.submitStatus).toMatch(FetchStatus.STANDBY);
-    expect(result.current.submitError).toBe(undefined);
-    expect(result.current.txStatus).toBe(Web3TxStatus.STANDBY);
-    expect(result.current.txError).toBe(undefined);
-    expect(result.current.txEtherscanURL).toBe('');
-    expect(result.current.txIsPromptOpen).toBe(false);
-
-    // wait for DaoRegistry & CouponOnboarding contracts from store
-    await waitForNextUpdate();
 
     const redeemableCoupon = {
       recipient: DEFAULT_ETH_ADDRESS,
@@ -108,30 +269,99 @@ describe('useRedeemCoupon unit tests', () => {
       dao: {daoAddress: '0x7BBAfD0edD40AeFAb0e93816DB5154E98f618103'},
     };
 
-    act(() => {
-      result.current.redeemCoupon(redeemableCoupon);
-    });
+    let mockWeb3Provider: FakeHttpProvider;
+    let web3Instance: Web3;
 
-    expect(result.current.submitStatus).toMatch(FetchStatus.PENDING);
-    expect(result.current.txStatus).toMatch(Web3TxStatus.AWAITING_CONFIRM);
-
-    await waitForValueToChange(() => result.current.txStatus);
-
-    expect(result.current.txStatus).toMatch(Web3TxStatus.PENDING);
-    expect(result.current.isInProcessOrDone).toBe(true);
-
-    // Setup: Mock RPC calls for `redeemCoupon`
     await act(async () => {
-      mockWeb3Provider.injectResult(...ethEstimateGas({web3Instance}));
-      mockWeb3Provider.injectResult(...ethGasPrice({web3Instance}));
-      mockWeb3Provider.injectResult(...sendTransaction({web3Instance}));
-      mockWeb3Provider.injectResult(...getTransactionReceipt({web3Instance}));
+      const {result, waitForNextUpdate, waitForValueToChange} =
+        await renderHook(() => useRedeemCoupon(), {
+          initialProps: {
+            useInit: true,
+            useWallet: true,
+            getProps: (p) => {
+              mockWeb3Provider = p.mockWeb3Provider;
+              web3Instance = p.web3Instance;
+            },
+          },
 
+          wrapper: Wrapper,
+        });
+
+      // Assert initial state
+      expect(result.current.isInProcessOrDone).toBe(false);
+      expect(result.current.redeemCoupon).toBeInstanceOf(Function);
+      expect(result.current.submitStatus).toMatch(FetchStatus.STANDBY);
+      expect(result.current.submitError).toBe(undefined);
+      expect(result.current.txStatus).toBe(Web3TxStatus.STANDBY);
+      expect(result.current.txError).toBe(undefined);
+      expect(result.current.txEtherscanURL).toBe('');
+      expect(result.current.txIsPromptOpen).toBe(false);
+
+      // wait for DaoRegistry & CouponOnboarding contracts from store
+      await waitForNextUpdate();
       await waitForNextUpdate();
 
-      expect(result.current.txStatus).toMatch(Web3TxStatus.FULFILLED);
-      expect(result.current.isInProcessOrDone).toBe(true);
-      expect(result.current.txIsPromptOpen).toBe(false);
+      act(() => {
+        // Mock tx result
+        mockWeb3Provider.injectResult(...ethEstimateGas({web3Instance}));
+        mockWeb3Provider.injectResult(...ethGasPrice({web3Instance}));
+        mockWeb3Provider.injectResult(...sendTransaction({web3Instance}));
+        mockWeb3Provider.injectResult(...getTransactionReceipt({web3Instance}));
+
+        // Run redeem coupon
+        result.current.redeemCoupon(redeemableCoupon);
+      });
+
+      expect(result.current.txStatus).toMatch(Web3TxStatus.AWAITING_CONFIRM);
+      expect(result.current.txIsPromptOpen).toBe(true);
+
+      await waitForValueToChange(() => result.current.txStatus);
+
+      expect(result.current.txStatus).toMatch(Web3TxStatus.PENDING);
+
+      await waitFor(() => {
+        // Mock `getConnectedMember`
+        mockWeb3Provider.injectResult(
+          web3Instance.eth.abi.encodeParameters(
+            ['uint256', 'bytes[]'],
+            [
+              0,
+              [
+                // For `getAddressIfDelegated` call
+                web3Instance.eth.abi.encodeParameter(
+                  'address',
+                  DEFAULT_ETH_ADDRESS
+                ),
+                // For `members` call
+                web3Instance.eth.abi.encodeParameter('uint8', '1'),
+                // For `isActiveMember` call
+                web3Instance.eth.abi.encodeParameter('bool', true),
+                // For `getCurrentDelegateKey` call
+                web3Instance.eth.abi.encodeParameter(
+                  'address',
+                  DEFAULT_ETH_ADDRESS
+                ),
+              ],
+            ]
+          ),
+          {debugName: '`getConnectedMember`'}
+        );
+      });
+
+      await waitFor(() => {
+        expect(result.current.submitError?.message).toMatch(
+          /something went wrong while updating the coupon\./i
+        );
+
+        expect(result.current.isInProcessOrDone).toBe(false);
+        expect(result.current.submitStatus).toMatch(FetchStatus.REJECTED);
+        expect(result.current.txError).toBe(undefined);
+
+        // No etherscan URL for Ganache
+        expect(result.current.txEtherscanURL).toBe('');
+        expect(result.current.txIsPromptOpen).toBe(false);
+        expect(result.current.txStatus).toMatch(Web3TxStatus.FULFILLED);
+      });
     });
   });
 });

--- a/src/pages/governance/GovernanceProposals.unit.test.tsx
+++ b/src/pages/governance/GovernanceProposals.unit.test.tsx
@@ -104,8 +104,7 @@ describe('GovernanceProposals unit tests', () => {
               web3Instance.eth.abi.encodeParameter('uint256', '200000'),
             ],
           ]
-        ),
-        {abi: MulticallABI, abiMethodName: 'aggregate'}
+        )
       );
     });
 

--- a/src/pages/membership/CreateMembershipProposal.unit.test.tsx
+++ b/src/pages/membership/CreateMembershipProposal.unit.test.tsx
@@ -34,8 +34,7 @@ describe('CreateMembershipProposal unit tests', () => {
             web3Instance.eth.abi.encodeParameter(
               'uint256',
               '123000000000000000000'
-            ),
-            {abiMethodName: 'eth_getBalance'}
+            )
           );
         }}>
         <CreateMembershipProposal />
@@ -72,8 +71,7 @@ describe('CreateMembershipProposal unit tests', () => {
             web3Instance.eth.abi.encodeParameter(
               'uint256',
               '123000000000000000000'
-            ),
-            {abiMethodName: 'eth_getBalance'}
+            )
           );
 
           // Mock `multicall` in useCheckApplicant hook

--- a/src/test/Wrapper.tsx
+++ b/src/test/Wrapper.tsx
@@ -178,13 +178,6 @@ export default function Wrapper(
     };
   }, [getVotingAdapterNameMock]);
 
-  useEffect(() => {}, [
-    mockWeb3Provider,
-    useInit,
-    web3Instance.eth.abi,
-    web3Instance.utils,
-  ]);
-
   useEffect(() => {
     /**
      * Setup for `getConnectedMember` in `<Init />`
@@ -213,7 +206,8 @@ export default function Wrapper(
               ),
             ],
           ]
-        )
+        ),
+        {debugName: '<Wrapper /> multicall for `getConnectedMember`'}
       );
     }
   }, [mockWeb3Provider, useInit, useWallet, web3Instance]);

--- a/src/test/helpers/FakeHttpProvider.ts
+++ b/src/test/helpers/FakeHttpProvider.ts
@@ -1,34 +1,16 @@
-const abiDecoder = require('abi-decoder');
-
 type ResponseStub = {
   jsonrpc: '2.0';
   id: number;
   result: any;
-
-  /**
-   * @note Added this to help us respond to specific mocked calls
-   */
-  __abiMethodName?: string;
-  /**
-   * @note Added this to help us respond to specific mocked calls
-   */
-  __rpcMethodName?: string;
-  /**
-   * @note Added this to help us respond to specific mocked calls
-   */
-  __abi?: Record<string, any>;
+  debugName?: string;
 };
 
 type ErrorStub = {
   jsonrpc: '2.0';
   id: number;
   error: ResponseError;
+  debugName?: string;
 };
-
-type Validation = (
-  payload: Record<string, any>,
-  callback: (e: ErrorStub, r: Record<string, any>) => void
-) => void;
 
 type ResponseError = {
   code: number;
@@ -36,82 +18,66 @@ type ResponseError = {
 };
 
 export type InjectResultOptions = {
-  abiMethodName?: string;
-  rpcMethodName?: string;
-  abi?: Record<string, any>;
+  /**
+   * Optional method name to be output for when debugging is used.
+   */
+  debugName?: string;
+};
+
+export type InjectErrorOptions = {
+  /**
+   * Optional method name to be output for when debugging is used.
+   */
+  debugName?: string;
 };
 
 /**
  * FakeHttpProvider
  *
- * Copied from: https://github.com/ethereum/web3.js
- * Implementation was altered to fit our needs of adding
- * specific responses for a method call, instead of a simple indexed/first-in-first-out
- * response list (this simpler way was not altered - still works).
+ * Copied, and altered, from: https://github.com/ethereum/web3.js
  *
  * @see https://github.com/ethereum/web3.js/blob/edf481d37ed0c4c4caae7a25619704010ac3639e/test/helpers/FakeHttpProvider.js
  */
 
 export class FakeHttpProvider {
   countId: number;
-  getResponseStub: () => ResponseStub;
-  getErrorStub: () => ErrorStub;
-  response: Array<ResponseStub>;
   error: Array<ErrorStub>;
-  validation: Array<Validation>;
+  isDebugActive: boolean;
+  response: Array<ResponseStub>;
 
   constructor() {
     this.countId = 1;
-    this.getResponseStub = function () {
-      return {
-        jsonrpc: '2.0',
-        id: this.countId,
-        result: null,
-      };
-    };
-    this.getErrorStub = function () {
-      return {
-        jsonrpc: '2.0',
-        id: this.countId,
-        error: {
-          code: 1234,
-          message: 'Stub error',
-        },
-      };
-    };
-
-    this.response = [];
     this.error = [];
-    this.validation = [];
+    this.isDebugActive = false;
+    this.response = [];
   }
 
-  /**
-   * @note Use `request`
-   */
-  /* send(
-    payload: Record<string, any>,
-    callback: (e: ErrorStub, r: Record<string, any>) => void
-  ) {
-    // set id
-    if (payload.id) this.countId = payload.id;
+  createResponseStub(
+    result: any = null,
+    options?: InjectResultOptions
+  ): ResponseStub {
+    return {
+      jsonrpc: '2.0',
+      id: this.countId,
+      result,
+      debugName: options?.debugName,
+    };
+  }
 
-    const validation = this.validation.shift();
-
-    if (validation) {
-      // imitate plain json object
-      validation(JSON.parse(JSON.stringify(payload)), callback);
-    }
-
-    const response = this.getResponseOrError(
-      'response',
-      payload
-    ) as ResponseStub;
-    const error = this.getResponseOrError('error', payload) as ErrorStub;
-
-    setTimeout(function () {
-      callback(error, response);
-    }, 1);
-  } */
+  createErrorStub(
+    error: ResponseError = {
+      code: 1234,
+      message: 'Stub error',
+    },
+    options?: InjectErrorOptions
+  ): ErrorStub {
+    return {
+      jsonrpc: '2.0',
+      id: this.countId,
+      error,
+      debugName: options?.debugName,
+    };
+  }
 
   /**
    * Use this instead of `send`.
@@ -124,119 +90,75 @@ export class FakeHttpProvider {
     params?: any[] | Record<string, any>;
   }): Promise<any> {
     try {
-      const response = this.getResponseOrError(
+      const {result, debugName} = (this.getResponseOrError(
         'response',
         payload
-      ) as ResponseStub;
+      ) || {}) as ResponseStub;
 
-      const error = this.getResponseOrError('error', payload) as ErrorStub;
+      const {error} =
+        (this.getResponseOrError('error', payload) as ErrorStub) || {};
 
-      if (error) {
-        throw error.error;
+      if (this.isDebugActive) {
+        console.log(
+          '-------DEBUG: `FakeHttpProvider`-------' +
+            '\nTYPE: ' +
+            (error ? 'error' : 'response') +
+            '\nMETHOD: ' +
+            payload.method +
+            '\nDEBUG METHOD NAME: ' +
+            debugName +
+            '\nENCODED RESULT: ' +
+            result
+        );
       }
 
-      return response.result;
+      if (error) {
+        throw error;
+      }
+
+      return result;
     } catch (error) {
       throw error;
     }
   }
 
   getResponseOrError(type: 'response' | 'error', payload: Record<string, any>) {
-    let response;
-
-    /**
-     * @note Added this to help us respond to specific mocked calls
-     */
-    const namedResponseIndex = this.response.findIndex((r) => {
-      if (!r.__abiMethodName && !r.__rpcMethodName) return false;
-
-      const decodedName =
-        r.__abi && r.__abiMethodName && payload.params[0]?.data
-          ? this.decodeMethodName(payload.params[0].data, r.__abi)
-          : '';
-
-      return (
-        decodedName === r.__abiMethodName ||
-        payload.method === r.__rpcMethodName
-      );
-    });
+    let result:
+      | ResponseStub
+      | ErrorStub
+      | ResponseStub[]
+      | ErrorStub[]
+      | undefined;
 
     if (type === 'error') {
-      response = this.error.shift();
-    } else if (namedResponseIndex >= 0) {
-      /**
-       * @note Added this to help us respond to specific mocked calls
-       */
-      response = this.response[namedResponseIndex];
-      this.response = this.response.filter((_, i) => i !== namedResponseIndex);
+      result = this.error.shift();
     } else {
-      response = this.response.shift() || this.getResponseStub();
+      result = this.response.shift() || this.createResponseStub();
     }
 
-    if (response) {
-      if (Array.isArray(response)) {
-        response = response.map((resp, index) => {
-          resp.id = payload[index] ? payload[index].id : this.countId++;
-          return resp;
+    if (result) {
+      if (Array.isArray(result)) {
+        result = result.map((r, index) => {
+          r.id = payload[index] ? payload[index].id : this.countId++;
+          return r;
         });
-      } else response.id = payload.id;
+      } else {
+        result.id = payload.id;
+      }
     }
 
-    return response;
+    return result;
   }
 
   injectResult(result: any, options?: InjectResultOptions) {
-    const response = this.getResponseStub();
-    response.result = result;
-
-    /**
-     * @note Added this to help us respond to specific mocked calls
-     */
-    if (options && options.abiMethodName) {
-      response.__abiMethodName = options.abiMethodName;
-    }
-
-    /**
-     * @note Added this to help us respond to specific mocked calls
-     */
-    if (options && options.rpcMethodName) {
-      response.__rpcMethodName = options.rpcMethodName;
-    }
-
-    /**
-     * @note Added this to help us respond to specific mocked calls
-     */
-    if (options && options.abi) {
-      response.__abi = options.abi;
-    }
-
-    this.response.push(response);
+    this.response.push(this.createResponseStub(result, options));
   }
 
-  injectError(error: ResponseError) {
-    const errorStub = this.getErrorStub();
-    errorStub.error = error; // message, code
-
-    this.error.push(errorStub);
+  injectError(error: ResponseError, options?: InjectErrorOptions) {
+    this.error.push(this.createErrorStub(error, options));
   }
 
-  injectValidation(callback: () => void) {
-    this.validation.push(callback);
-  }
-
-  /**
-   * @note Added this to help us respond to specific mocked calls
-   */
-  private decodeMethodName(
-    encodedMethodSignature: string,
-    abi: Record<string, any>
-  ) {
-    abiDecoder.addABI(abi);
-
-    const {name = ''} = abiDecoder.decodeMethod(encodedMethodSignature) || {};
-
-    abiDecoder.removeABI(abi);
-
-    return name;
+  debug(shouldStart: boolean = true) {
+    this.isDebugActive = shouldStart;
   }
 }

--- a/src/test/web3Responses/estimateGas.ts
+++ b/src/test/web3Responses/estimateGas.ts
@@ -12,5 +12,5 @@ export const ethEstimateGas = ({
   web3Instance,
 }: TestWeb3ResponseArgs): TestWeb3ResponseReturn<string> => [
   web3Instance.eth.abi.encodeParameter('uint256', result ?? 12312),
-  {rpcMethodName: 'eth_estimateGas'},
+  {debugName: '`ethEstimateGas` helper'},
 ];

--- a/src/test/web3Responses/ethBlockNumber.ts
+++ b/src/test/web3Responses/ethBlockNumber.ts
@@ -12,5 +12,5 @@ export const ethBlockNumber = ({
   web3Instance,
 }: TestWeb3ResponseArgs): TestWeb3ResponseReturn<string> => [
   web3Instance.eth.abi.encodeParameter('uint256', result ?? 100),
-  {rpcMethodName: 'eth_blockNumber'},
+  {debugName: '`ethBlockNumber` helper'},
 ];

--- a/src/test/web3Responses/gasPrice.ts
+++ b/src/test/web3Responses/gasPrice.ts
@@ -12,5 +12,5 @@ export const ethGasPrice = ({
   web3Instance,
 }: TestWeb3ResponseArgs): TestWeb3ResponseReturn<string> => [
   web3Instance.eth.abi.encodeParameter('uint256', result ?? 8049999872),
-  {rpcMethodName: 'eth_gasPrice'},
+  {debugName: '`ethGasPrice` helper'},
 ];

--- a/src/test/web3Responses/getCurrentDelegateKey.ts
+++ b/src/test/web3Responses/getCurrentDelegateKey.ts
@@ -1,6 +1,5 @@
 import {DEFAULT_ETH_ADDRESS} from '../helpers';
 import {TestWeb3ResponseArgs, TestWeb3ResponseReturn} from './types';
-import DAORegistryABI from '../../truffle-contracts/DaoRegistry.json';
 
 /**
  * getCurrentDelegateKey
@@ -16,6 +15,6 @@ export const getCurrentDelegateKey = ({
   return [
     result ??
       web3Instance.eth.abi.encodeParameter('address', DEFAULT_ETH_ADDRESS),
-    {abiMethodName: 'getCurrentDelegateKey', abi: DAORegistryABI},
+    {debugName: '`getCurrentDelegateKey` helper'},
   ];
 };

--- a/src/test/web3Responses/getTransactionReceipt.ts
+++ b/src/test/web3Responses/getTransactionReceipt.ts
@@ -25,5 +25,5 @@ export const getTransactionReceipt = ({
     logsBloom: DEFAULT_ETH_ADDRESS, // 256 byte bloom filter
     status: '0x1',
   },
-  {rpcMethodName: 'eth_getTransactionReceipt'},
+  {debugName: '`getTransactionReceipt` helper'},
 ];

--- a/src/test/web3Responses/member.ts
+++ b/src/test/web3Responses/member.ts
@@ -17,7 +17,7 @@ export const memberAddressesByDelegatedKey = ({
   return [
     result ??
       web3Instance.eth.abi.encodeParameter('address', DEFAULT_ETH_ADDRESS),
-    {abiMethodName: 'memberAddressesByDelegatedKey', abi: DAORegistryABI},
+    {debugName: '`memberAddressesByDelegatedKey` helper'},
   ];
 };
 
@@ -36,6 +36,6 @@ export const balanceOfMember = ({
 }: TestWeb3ResponseArgs): TestWeb3ResponseReturn<string> => {
   return [
     result ?? web3Instance.eth.abi.encodeParameter('uint160', 100),
-    {abiMethodName: 'balanceOf', abi: BankExtensionABI},
+    {debugName: '`balanceOfMember` helper'},
   ];
 };

--- a/src/test/web3Responses/sendTransaction.ts
+++ b/src/test/web3Responses/sendTransaction.ts
@@ -11,5 +11,5 @@ export const sendTransaction = ({
   result,
 }: TestWeb3ResponseArgs): TestWeb3ResponseReturn<string> => [
   result ?? '0xe670ec64341771606e55d6b4ca35a1a6b75ee3d5145a99d05921026d1527331',
-  {rpcMethodName: 'eth_sendTransaction'},
+  {debugName: '`sendTransaction` helper'},
 ];

--- a/src/test/web3Responses/signTypedDataV4.ts
+++ b/src/test/web3Responses/signTypedDataV4.ts
@@ -16,5 +16,5 @@ export const signTypedDataV4 = ({
       'bytes32',
       web3Instance.utils.toHex('great signature')
     ),
-  {rpcMethodName: 'eth_signTypedData_v4'},
+  {debugName: '`signTypedDataV4` helper'},
 ];

--- a/src/test/web3Responses/types.ts
+++ b/src/test/web3Responses/types.ts
@@ -7,4 +7,4 @@ export type TestWeb3ResponseArgs = {
   web3Instance: Web3;
 };
 
-export type TestWeb3ResponseReturn<T> = [T, InjectResultOptions];
+export type TestWeb3ResponseReturn<T> = [T, InjectResultOptions?];


### PR DESCRIPTION
Fixes #428 

✨ **Updates**

 - Simplifies `FakeHttpProvider` and provides new `debug` method
 - Updates tests which broke due to `FakeHttpProvider` updates
 - Updates code which used the old `FakeHttpProvider` API


⛔️ **Removes**

 - `abi-decoder` dev dependency
