### PR TITLE
updates web3@1.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "redux": "^4.1.0",
         "redux-thunk": "^2.3.0",
         "web-vitals": "^2.1.0",
-        "web3": "^1.3.6",
+        "web3": "^1.5.0",
         "web3modal": "^1.9.3"
       },
       "devDependencies": {
@@ -1999,21 +1999,21 @@
       }
     },
     "node_modules/@ethereumjs/common": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@ethereumjs/common/-/common-2.3.1.tgz",
-      "integrity": "sha512-V8hrULExoq0H4HFs3cCmdRGbgmipmlNzak6Xg34nHYfQyqkSdrCuflvYjyWmsNpI8GtrcZhzifAbgX/1C1Cjwg==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@ethereumjs/common/-/common-2.4.0.tgz",
+      "integrity": "sha512-UdkhFWzWcJCZVsj1O/H8/oqj/0RVYjLc1OhPjBrQdALAkQHpCp8xXI4WLnuGTADqTdJZww0NtgwG+TRPkXt27w==",
       "dependencies": {
         "crc-32": "^1.2.0",
-        "ethereumjs-util": "^7.0.10"
+        "ethereumjs-util": "^7.1.0"
       }
     },
     "node_modules/@ethereumjs/tx": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@ethereumjs/tx/-/tx-3.2.1.tgz",
-      "integrity": "sha512-i9V39OtKvwWos1uVNZxdVhd7zFOyzFLjgt69CoiOY0EmXugS0HjO3uxpLBSglDKFMRriuGqw6ddKEv+RP1UNEw==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@ethereumjs/tx/-/tx-3.3.0.tgz",
+      "integrity": "sha512-yTwEj2lVzSMgE6Hjw9Oa1DZks/nKTWM8Wn4ykDNapBPua2f4nXO3qKnni86O6lgDj5fVNRqbDsD0yy7/XNGDEA==",
       "dependencies": {
-        "@ethereumjs/common": "^2.3.1",
-        "ethereumjs-util": "^7.0.10"
+        "@ethereumjs/common": "^2.4.0",
+        "ethereumjs-util": "^7.1.0"
       }
     },
     "node_modules/@ethersproject/abi": {
@@ -10270,9 +10270,9 @@
       }
     },
     "node_modules/ethereumjs-util": {
-      "version": "7.0.10",
-      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.0.10.tgz",
-      "integrity": "sha512-c/xThw6A+EAnej5Xk5kOzFzyoSnw0WX0tSlZ6pAsfGVvQj3TItaDg9b1+Fz1RJXA+y2YksKwQnuzgt1eY6LKzw==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.1.0.tgz",
+      "integrity": "sha512-kR+vhu++mUDARrsMMhsjjzPduRVAeundLGXucGRHF3B4oEltOUspfgCVco4kckucj3FMlLaZHUl9n7/kdmr6Tw==",
       "dependencies": {
         "@types/bn.js": "^5.1.0",
         "bn.js": "^5.1.2",
@@ -24676,9 +24676,9 @@
       }
     },
     "node_modules/swarm-js/node_modules/tar": {
-      "version": "4.4.13",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.13.tgz",
-      "integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
+      "version": "4.4.15",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.15.tgz",
+      "integrity": "sha512-ItbufpujXkry7bHH9NpQyTXPbJ72iTlXgkBAYsAjDXk3Ds8t/3NfO5P4xZGy7u+sYuQUbimgzswX4uQIEeNVOA==",
       "dependencies": {
         "chownr": "^1.1.1",
         "fs-minipass": "^1.2.5",
@@ -25489,11 +25489,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/underscore": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.12.1.tgz",
-      "integrity": "sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw=="
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "1.0.4",
@@ -26397,33 +26392,32 @@
       "integrity": "sha512-npEyJP8jHf3J71t1tRTEtz9FeKp8H2udWJUUq5ykfPhhstr//TUxiYhIEzLNwk4zv2ybAilMn7v7N6Mxmuitmg=="
     },
     "node_modules/web3": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/web3/-/web3-1.4.0.tgz",
-      "integrity": "sha512-faT3pIX+1tuo+wqmUFQPe10MUGaB1UvRYxw9dmVJFLxaRAIfXErSilOf3jFhSwKbbPNkwG0bTiudCLN9JgeS7A==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/web3/-/web3-1.5.0.tgz",
+      "integrity": "sha512-p6mOU+t11tV5Z0W9ISO2ReZlbB1ICp755ogl3OXOWZ+/oWy12wwnIva+z+ypsZc3P8gaoGaTvEwSfXM9NF164w==",
       "hasInstallScript": true,
       "dependencies": {
-        "web3-bzz": "1.4.0",
-        "web3-core": "1.4.0",
-        "web3-eth": "1.4.0",
-        "web3-eth-personal": "1.4.0",
-        "web3-net": "1.4.0",
-        "web3-shh": "1.4.0",
-        "web3-utils": "1.4.0"
+        "web3-bzz": "1.5.0",
+        "web3-core": "1.5.0",
+        "web3-eth": "1.5.0",
+        "web3-eth-personal": "1.5.0",
+        "web3-net": "1.5.0",
+        "web3-shh": "1.5.0",
+        "web3-utils": "1.5.0"
       },
       "engines": {
         "node": ">=8.0.0"
       }
     },
     "node_modules/web3-bzz": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.4.0.tgz",
-      "integrity": "sha512-KhXmz8hcfGsqhplB7NrekAeNkG2edHjXV4bL3vnXde8RGMWpabpSNxuwiGv+dv/3nWlrHatH0vGooONYCkP5TA==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.5.0.tgz",
+      "integrity": "sha512-IqlecWpwTMO/O5qa0XZZubQh4GwAtO/CR+e2FQ/7oB5eXQyre3DZ/MYu8s5HCLxCR33Fcqda9q2dbNtm1wSQYw==",
       "hasInstallScript": true,
       "dependencies": {
         "@types/node": "^12.12.6",
         "got": "9.6.0",
-        "swarm-js": "^0.1.40",
-        "underscore": "1.12.1"
+        "swarm-js": "^0.1.40"
       },
       "engines": {
         "node": ">=8.0.0"
@@ -26449,9 +26443,9 @@
       }
     },
     "node_modules/web3-bzz/node_modules/@types/node": {
-      "version": "12.20.15",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.15.tgz",
-      "integrity": "sha512-F6S4Chv4JicJmyrwlDkxUdGNSplsQdGwp1A0AJloEVDirWdZOAiRHhovDlsFkKUrquUXhz1imJhXHsf59auyAg=="
+      "version": "12.20.18",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.18.tgz",
+      "integrity": "sha512-YoTiIwdKxM3VLiY2sM05x4iGuTveYiCcDaUVmo1L5ndrXxPGW/NEoZu+pGcBirziomizcZsnsQoemikKcB2fRA=="
     },
     "node_modules/web3-bzz/node_modules/cacheable-request": {
       "version": "6.1.0",
@@ -26602,55 +26596,53 @@
       }
     },
     "node_modules/web3-core": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.4.0.tgz",
-      "integrity": "sha512-VRNMNqwzvPeKIet2l9BMApPHoUv0UqwaZH0lZJhG2RBko42w9Xls+pQwfVNSV16j04t/ehm1aLRV2Sx6lzVfRg==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.5.0.tgz",
+      "integrity": "sha512-1o/etaPSK8tFOWTA6df3t9J6ez4epeyzlNmyh/gx8uHasfa16XLKD8//A9T+O/TmvyQAaA4hWAsQcvlRcuaZ8Q==",
       "dependencies": {
         "@types/bn.js": "^4.11.5",
         "@types/node": "^12.12.6",
         "bignumber.js": "^9.0.0",
-        "web3-core-helpers": "1.4.0",
-        "web3-core-method": "1.4.0",
-        "web3-core-requestmanager": "1.4.0",
-        "web3-utils": "1.4.0"
+        "web3-core-helpers": "1.5.0",
+        "web3-core-method": "1.5.0",
+        "web3-core-requestmanager": "1.5.0",
+        "web3-utils": "1.5.0"
       },
       "engines": {
         "node": ">=8.0.0"
       }
     },
     "node_modules/web3-core-helpers": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.4.0.tgz",
-      "integrity": "sha512-8Ebq0nmRfzw7iPoXbIRHEWOuPh+1cOV3OOEvKm5Od3McZOjja914vdk+DM3MgmbSpDzYJRFM6KoF0+Z/U/1bPw==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.5.0.tgz",
+      "integrity": "sha512-7s5SrJbG5O0C0Oi9mqKLYchco72djZhk59B7kTla5vUorAxMc99SY7k9BoDgwbFl2dlZon2GtFUEW2RXUNkb1g==",
       "dependencies": {
-        "underscore": "1.12.1",
-        "web3-eth-iban": "1.4.0",
-        "web3-utils": "1.4.0"
+        "web3-eth-iban": "1.5.0",
+        "web3-utils": "1.5.0"
       },
       "engines": {
         "node": ">=8.0.0"
       }
     },
     "node_modules/web3-core-method": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.4.0.tgz",
-      "integrity": "sha512-KW9922fEkgKu8zDcJR8Iikg/epsuWMArAUVTipKVwzAI5TVdvOMRgSe/b7IIDRUIeoeXMARmJ+PrAlx+IU2acQ==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.5.0.tgz",
+      "integrity": "sha512-izPhpjbn9jVBjMeFcsU7a5+/nqni9hS5oU+d00HJGTVbp8KV6zplhYw4GjkRqyy6OQzooO8Gx2MMUyRdv5x1wg==",
       "dependencies": {
         "@ethersproject/transactions": "^5.0.0-beta.135",
-        "underscore": "1.12.1",
-        "web3-core-helpers": "1.4.0",
-        "web3-core-promievent": "1.4.0",
-        "web3-core-subscriptions": "1.4.0",
-        "web3-utils": "1.4.0"
+        "web3-core-helpers": "1.5.0",
+        "web3-core-promievent": "1.5.0",
+        "web3-core-subscriptions": "1.5.0",
+        "web3-utils": "1.5.0"
       },
       "engines": {
         "node": ">=8.0.0"
       }
     },
     "node_modules/web3-core-promievent": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.4.0.tgz",
-      "integrity": "sha512-YEwko22kcry7lHwbe0k80BrjXCZ+73jMdvZtptRH5k2B+XZ1XtmXwYL1PFIlZy9V0zgZijdg+3GabCnAHjVXAw==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.5.0.tgz",
+      "integrity": "sha512-7GkbOIMtcp1qN8LRMMmwIhulzEldT+3Mu7ii2WgAcFFKT1yzUl6Gmycf8mmoEKpAuADAQ9Qeyk0PskTR6rTYlQ==",
       "dependencies": {
         "eventemitter3": "4.0.4"
       },
@@ -26664,29 +26656,27 @@
       "integrity": "sha512-rlaVLnVxtxvoyLsQQFBx53YmXHDxRIzzTLbdfxqi4yocpSjAxXwkU0cScM5JgSKMqEhrZpnvQ2D9gjylR0AimQ=="
     },
     "node_modules/web3-core-requestmanager": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.4.0.tgz",
-      "integrity": "sha512-qIwKJO5T0KkUAIL7y9JRSUkk3+LaCwghdUHK8FzbMvq6R1W9lgCBnccqFGEI76EJjHvsiw4kEKBEXowdB3xenQ==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.5.0.tgz",
+      "integrity": "sha512-Sr5T2JuXOAsINJ2tf7Rgi2a+Dy2suBDKT8eMc1pcspPmaBhvTKOQfM9XdsO4yjJKYw6tt/Tagw4GKZm4IOx7mw==",
       "dependencies": {
-        "underscore": "1.12.1",
         "util": "^0.12.0",
-        "web3-core-helpers": "1.4.0",
-        "web3-providers-http": "1.4.0",
-        "web3-providers-ipc": "1.4.0",
-        "web3-providers-ws": "1.4.0"
+        "web3-core-helpers": "1.5.0",
+        "web3-providers-http": "1.5.0",
+        "web3-providers-ipc": "1.5.0",
+        "web3-providers-ws": "1.5.0"
       },
       "engines": {
         "node": ">=8.0.0"
       }
     },
     "node_modules/web3-core-subscriptions": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.4.0.tgz",
-      "integrity": "sha512-/UMC9rSLEd0U+h6Qanx6CM29o/cfUyGWgl/HM6O/AIuth9G+34QBuKDa11Gr2Qg6F8Lr9tSFm8QIGVniOx9i5A==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.5.0.tgz",
+      "integrity": "sha512-dx9P1mZvJkQRiYpSo9SvFhYNzy5E9GHeLOc3uqxPaDxKU7Cu9fJnFHo/P6+wfD6ZhGIP23ZLK/uyor5UpdTqDQ==",
       "dependencies": {
         "eventemitter3": "4.0.4",
-        "underscore": "1.12.1",
-        "web3-core-helpers": "1.4.0"
+        "web3-core-helpers": "1.5.0"
       },
       "engines": {
         "node": ">=8.0.0"
@@ -26706,50 +26696,48 @@
       }
     },
     "node_modules/web3-core/node_modules/@types/node": {
-      "version": "12.20.15",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.15.tgz",
-      "integrity": "sha512-F6S4Chv4JicJmyrwlDkxUdGNSplsQdGwp1A0AJloEVDirWdZOAiRHhovDlsFkKUrquUXhz1imJhXHsf59auyAg=="
+      "version": "12.20.18",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.18.tgz",
+      "integrity": "sha512-YoTiIwdKxM3VLiY2sM05x4iGuTveYiCcDaUVmo1L5ndrXxPGW/NEoZu+pGcBirziomizcZsnsQoemikKcB2fRA=="
     },
     "node_modules/web3-eth": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.4.0.tgz",
-      "integrity": "sha512-L990eMJeWh4h/Z3M8MJb9HrKq8tqvzdGZ7igdzd6Ba3B/VKgGFAJ/4XIqtLwAJ1Wg5Cj8my60tYY+34c2cLefw==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.5.0.tgz",
+      "integrity": "sha512-31ni3YliTDYLKuWt8naitZ4Ru86whZlqvz6kFzCaBaCR/EumzA9ejzNbcX9okio9zUtKSHH37Bk0+WogfU9Jqg==",
       "dependencies": {
-        "underscore": "1.12.1",
-        "web3-core": "1.4.0",
-        "web3-core-helpers": "1.4.0",
-        "web3-core-method": "1.4.0",
-        "web3-core-subscriptions": "1.4.0",
-        "web3-eth-abi": "1.4.0",
-        "web3-eth-accounts": "1.4.0",
-        "web3-eth-contract": "1.4.0",
-        "web3-eth-ens": "1.4.0",
-        "web3-eth-iban": "1.4.0",
-        "web3-eth-personal": "1.4.0",
-        "web3-net": "1.4.0",
-        "web3-utils": "1.4.0"
+        "web3-core": "1.5.0",
+        "web3-core-helpers": "1.5.0",
+        "web3-core-method": "1.5.0",
+        "web3-core-subscriptions": "1.5.0",
+        "web3-eth-abi": "1.5.0",
+        "web3-eth-accounts": "1.5.0",
+        "web3-eth-contract": "1.5.0",
+        "web3-eth-ens": "1.5.0",
+        "web3-eth-iban": "1.5.0",
+        "web3-eth-personal": "1.5.0",
+        "web3-net": "1.5.0",
+        "web3-utils": "1.5.0"
       },
       "engines": {
         "node": ">=8.0.0"
       }
     },
     "node_modules/web3-eth-abi": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.4.0.tgz",
-      "integrity": "sha512-FtmWipG/dSSkTGFb72JCwky7Jd0PIvd0kGTInWQwIEZlw5qMOYl61WZ9gwfojFHvHF6q1eKncerQr+MRXHO6zg==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.5.0.tgz",
+      "integrity": "sha512-rfT/SvfZY9+SNJRzTHxLFaebQRBhS67tGqUqLxlyy6EsAcEmIs/g4mAUH5atYwPE9bOQeiVoLKLbwJEBIcw86w==",
       "dependencies": {
         "@ethersproject/abi": "5.0.7",
-        "underscore": "1.12.1",
-        "web3-utils": "1.4.0"
+        "web3-utils": "1.5.0"
       },
       "engines": {
         "node": ">=8.0.0"
       }
     },
     "node_modules/web3-eth-accounts": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.4.0.tgz",
-      "integrity": "sha512-tETHBvfO3Z7BXZ7HJIwuX7ol6lPefP55X7b4IiX82C1PujHwsxENY7c/3wyxzqKoDyH6zfyEQo17yhxkhsM1oA==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.5.0.tgz",
+      "integrity": "sha512-tqvF2bKECaS6jDux8h1dkdsrfb5SHIVVA6hu2lJmZNlTBqFIq2A8rfOkqcanie6Vh5n5U7Dnc2LUoN9rxgaSSg==",
       "dependencies": {
         "@ethereumjs/common": "^2.3.0",
         "@ethereumjs/tx": "^3.2.1",
@@ -26757,12 +26745,11 @@
         "eth-lib": "0.2.8",
         "ethereumjs-util": "^7.0.10",
         "scrypt-js": "^3.0.1",
-        "underscore": "1.12.1",
         "uuid": "3.3.2",
-        "web3-core": "1.4.0",
-        "web3-core-helpers": "1.4.0",
-        "web3-core-method": "1.4.0",
-        "web3-utils": "1.4.0"
+        "web3-core": "1.5.0",
+        "web3-core-helpers": "1.5.0",
+        "web3-core-method": "1.5.0",
+        "web3-utils": "1.5.0"
       },
       "engines": {
         "node": ">=8.0.0"
@@ -26788,19 +26775,18 @@
       }
     },
     "node_modules/web3-eth-contract": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.4.0.tgz",
-      "integrity": "sha512-GfIhOzfp/ZXKd+1tFEH3ePq0DEsvq9XO5tOsI0REDtEYUj2GNxO5e/x/Fhekk7iLZ7xAqSzDMweFruDQ1fxn0A==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.5.0.tgz",
+      "integrity": "sha512-v4laiJRzdcoDwvqaMCzJH1BUosbTVsd01Qp+9v05Q94KycjkdeahPRXX6PEcUNW/ZF8N006iExUweGjajTZnTA==",
       "dependencies": {
         "@types/bn.js": "^4.11.5",
-        "underscore": "1.12.1",
-        "web3-core": "1.4.0",
-        "web3-core-helpers": "1.4.0",
-        "web3-core-method": "1.4.0",
-        "web3-core-promievent": "1.4.0",
-        "web3-core-subscriptions": "1.4.0",
-        "web3-eth-abi": "1.4.0",
-        "web3-utils": "1.4.0"
+        "web3-core": "1.5.0",
+        "web3-core-helpers": "1.5.0",
+        "web3-core-method": "1.5.0",
+        "web3-core-promievent": "1.5.0",
+        "web3-core-subscriptions": "1.5.0",
+        "web3-eth-abi": "1.5.0",
+        "web3-utils": "1.5.0"
       },
       "engines": {
         "node": ">=8.0.0"
@@ -26815,31 +26801,30 @@
       }
     },
     "node_modules/web3-eth-ens": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.4.0.tgz",
-      "integrity": "sha512-jR1KorjU1erpYFpFzsMXAWZnHhqUqWPBq/4+BGVj7/pJ43+A3mrE1eB0zl91Dwc1RTNwOhB02iOj1c9OlpGr3g==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.5.0.tgz",
+      "integrity": "sha512-NiaGfOnsCqP+3hOCeP3Q9IrlV/1ZCDiv8VmN1yF5Ya6n6YeO4TJU9MKP8i5038RFETjLIfGtXr5fthbsob30hA==",
       "dependencies": {
         "content-hash": "^2.5.2",
         "eth-ens-namehash": "2.0.8",
-        "underscore": "1.12.1",
-        "web3-core": "1.4.0",
-        "web3-core-helpers": "1.4.0",
-        "web3-core-promievent": "1.4.0",
-        "web3-eth-abi": "1.4.0",
-        "web3-eth-contract": "1.4.0",
-        "web3-utils": "1.4.0"
+        "web3-core": "1.5.0",
+        "web3-core-helpers": "1.5.0",
+        "web3-core-promievent": "1.5.0",
+        "web3-eth-abi": "1.5.0",
+        "web3-eth-contract": "1.5.0",
+        "web3-utils": "1.5.0"
       },
       "engines": {
         "node": ">=8.0.0"
       }
     },
     "node_modules/web3-eth-iban": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.4.0.tgz",
-      "integrity": "sha512-YNx748VzwiBe0gvtZjvU9BQsooZ9s9sAlmiDWJOMcvMbUTDhC7SvxA7vV/vrnOxL6oGHRh0U/azsYNxxlKiTBw==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.5.0.tgz",
+      "integrity": "sha512-cFfiPA8xs4lemMJjDb9KfXzPvs6rBrRl8y4rgvh/JWlZZgKolzo7KLXq4NR3oFd/C81s0Lslvz2st1EREp5CNA==",
       "dependencies": {
         "bn.js": "^4.11.9",
-        "web3-utils": "1.4.0"
+        "web3-utils": "1.5.0"
       },
       "engines": {
         "node": ">=8.0.0"
@@ -26851,34 +26836,34 @@
       "integrity": "sha512-c98Bf3tPniI+scsdk237ku1Dc3ujXQTSgyiPUDEOe7tRkhrqridvh8klBv0HCEso1OLOYcHuCv/cS6DNxKH+ZA=="
     },
     "node_modules/web3-eth-personal": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.4.0.tgz",
-      "integrity": "sha512-8Ip6xZ8plmWqAD4ESbKUIPVV9gfTAFFm0ff1FQIw9I9kYvFlBIPzukvm852w2SftGem+/iRH+2+2mK7HvuKXZQ==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.5.0.tgz",
+      "integrity": "sha512-FYBrzMS6q/df8ud1kAN1p6lqdP/pd0szogcuyrVyi++bFQiovnR+QosudFsbn/aAZPDHOEh0UV4P3KVKbLqw9g==",
       "dependencies": {
         "@types/node": "^12.12.6",
-        "web3-core": "1.4.0",
-        "web3-core-helpers": "1.4.0",
-        "web3-core-method": "1.4.0",
-        "web3-net": "1.4.0",
-        "web3-utils": "1.4.0"
+        "web3-core": "1.5.0",
+        "web3-core-helpers": "1.5.0",
+        "web3-core-method": "1.5.0",
+        "web3-net": "1.5.0",
+        "web3-utils": "1.5.0"
       },
       "engines": {
         "node": ">=8.0.0"
       }
     },
     "node_modules/web3-eth-personal/node_modules/@types/node": {
-      "version": "12.20.15",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.15.tgz",
-      "integrity": "sha512-F6S4Chv4JicJmyrwlDkxUdGNSplsQdGwp1A0AJloEVDirWdZOAiRHhovDlsFkKUrquUXhz1imJhXHsf59auyAg=="
+      "version": "12.20.18",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.18.tgz",
+      "integrity": "sha512-YoTiIwdKxM3VLiY2sM05x4iGuTveYiCcDaUVmo1L5ndrXxPGW/NEoZu+pGcBirziomizcZsnsQoemikKcB2fRA=="
     },
     "node_modules/web3-net": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.4.0.tgz",
-      "integrity": "sha512-41WkKobL+KnKC0CY0RZ1KhMMyR/hMFGlbHZQac4KtB7ro1UdXeK+RiYX+GzSr1h7j9Dj+dQZqyBs70cxmL9cPQ==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.5.0.tgz",
+      "integrity": "sha512-oGgEtO2fRtJjAp0K1/fvH247MeeDemFL+5tF+PxII9b/gBxnVe+MzP+oNLr4dTrweromjv34tioR3kUgsqwCWg==",
       "dependencies": {
-        "web3-core": "1.4.0",
-        "web3-core-method": "1.4.0",
-        "web3-utils": "1.4.0"
+        "web3-core": "1.5.0",
+        "web3-core-method": "1.5.0",
+        "web3-utils": "1.5.0"
       },
       "engines": {
         "node": ">=8.0.0"
@@ -26985,11 +26970,11 @@
       }
     },
     "node_modules/web3-providers-http": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.4.0.tgz",
-      "integrity": "sha512-A9nLF4XGZfDb1KYYuKRwHY1H90Ee/0I0CqQQEELI0yuY9eca50qdCHEg3sJhvqBIG44JCm83amOGxR8wi+76tQ==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.5.0.tgz",
+      "integrity": "sha512-y1RuxsCGrWdsIUyuZBEN+3F8trl3bDZNajwLS2KYBGlB99sWYZHPmvbAsBpaW1d/I12W0fQiWOVzp63L7KPTow==",
       "dependencies": {
-        "web3-core-helpers": "1.4.0",
+        "web3-core-helpers": "1.5.0",
         "xhr2-cookies": "1.1.0"
       },
       "engines": {
@@ -26997,26 +26982,24 @@
       }
     },
     "node_modules/web3-providers-ipc": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.4.0.tgz",
-      "integrity": "sha512-ul/tSNUI5anhdBGBV+FWFH9EJgO73/G21haFDEXvTnSJQa9/byj401H/E2Xd8BXGk+2XB+CCGLZBiuAjhhhtTA==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.5.0.tgz",
+      "integrity": "sha512-Hda9wlOaIJC9/qMOVkayK+fbBHDZBmPcoL7TfjQX7hrtZn8V3+gR27ciyRXmuW7QD3hDg7CJfe5uRK8brh3nSA==",
       "dependencies": {
         "oboe": "2.1.5",
-        "underscore": "1.12.1",
-        "web3-core-helpers": "1.4.0"
+        "web3-core-helpers": "1.5.0"
       },
       "engines": {
         "node": ">=8.0.0"
       }
     },
     "node_modules/web3-providers-ws": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.4.0.tgz",
-      "integrity": "sha512-E5XfF58RLXuCtGiMSXxXEtjceCfPli+I4MDYCKx/J/bDJ6qvLUM2OnnGEmE7pq1Z03h0xh1ZezaB/qoweK3ZIQ==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.5.0.tgz",
+      "integrity": "sha512-TCwOhu5WbuQCSUoar+U+7N1NqI4A6MlcdZqsC7AhTogYYtnXOPRWfiHMZtUP7Qw50GKJ37FIH3YDItcHTNHd6A==",
       "dependencies": {
         "eventemitter3": "4.0.4",
-        "underscore": "1.12.1",
-        "web3-core-helpers": "1.4.0",
+        "web3-core-helpers": "1.5.0",
         "websocket": "^1.0.32"
       },
       "engines": {
@@ -27029,24 +27012,24 @@
       "integrity": "sha512-rlaVLnVxtxvoyLsQQFBx53YmXHDxRIzzTLbdfxqi4yocpSjAxXwkU0cScM5JgSKMqEhrZpnvQ2D9gjylR0AimQ=="
     },
     "node_modules/web3-shh": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.4.0.tgz",
-      "integrity": "sha512-OZMkMgo+VZnu1ErhIFXW+5ExnPKQg9v8/2DHGVtNEwuC5OHYuAEF5U7MQgbxYJYwbRmxQCt/hA3VwKjnkbmSAA==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.5.0.tgz",
+      "integrity": "sha512-TwpcxXNh+fBnyRcCPPqVqaCB4IjSpVL2/5OR2WwCnZwejs1ife+pej8DYVZWm0m1tSzIDRTdNbsJf/DN0cAxYQ==",
       "hasInstallScript": true,
       "dependencies": {
-        "web3-core": "1.4.0",
-        "web3-core-method": "1.4.0",
-        "web3-core-subscriptions": "1.4.0",
-        "web3-net": "1.4.0"
+        "web3-core": "1.5.0",
+        "web3-core-method": "1.5.0",
+        "web3-core-subscriptions": "1.5.0",
+        "web3-net": "1.5.0"
       },
       "engines": {
         "node": ">=8.0.0"
       }
     },
     "node_modules/web3-utils": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.4.0.tgz",
-      "integrity": "sha512-b8mEhwh/J928Xk+SQFjtqrR2EGPhpknWLcIt9aCpVPVRXiqjUGo/kpOHKz0azu9c6/onEJ9tWXZt0cVjmH0N5Q==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.5.0.tgz",
+      "integrity": "sha512-hNyw7Oxi6TM3ivXmv4hK5Cvyi9ML3UoKtcCYvLF9woPWh5v2dwCCVO1U3Iq5HHK7Dqq28t1d4CxWHqUfOfAkgg==",
       "dependencies": {
         "bn.js": "^4.11.9",
         "eth-lib": "0.2.8",
@@ -27054,7 +27037,6 @@
         "ethjs-unit": "0.1.6",
         "number-to-bn": "1.7.0",
         "randombytes": "^2.1.0",
-        "underscore": "1.12.1",
         "utf8": "3.0.0"
       },
       "engines": {
@@ -30256,21 +30238,21 @@
       }
     },
     "@ethereumjs/common": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/@ethereumjs/common/-/common-2.3.1.tgz",
-      "integrity": "sha512-V8hrULExoq0H4HFs3cCmdRGbgmipmlNzak6Xg34nHYfQyqkSdrCuflvYjyWmsNpI8GtrcZhzifAbgX/1C1Cjwg==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/@ethereumjs/common/-/common-2.4.0.tgz",
+      "integrity": "sha512-UdkhFWzWcJCZVsj1O/H8/oqj/0RVYjLc1OhPjBrQdALAkQHpCp8xXI4WLnuGTADqTdJZww0NtgwG+TRPkXt27w==",
       "requires": {
         "crc-32": "^1.2.0",
-        "ethereumjs-util": "^7.0.10"
+        "ethereumjs-util": "^7.1.0"
       }
     },
     "@ethereumjs/tx": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/@ethereumjs/tx/-/tx-3.2.1.tgz",
-      "integrity": "sha512-i9V39OtKvwWos1uVNZxdVhd7zFOyzFLjgt69CoiOY0EmXugS0HjO3uxpLBSglDKFMRriuGqw6ddKEv+RP1UNEw==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@ethereumjs/tx/-/tx-3.3.0.tgz",
+      "integrity": "sha512-yTwEj2lVzSMgE6Hjw9Oa1DZks/nKTWM8Wn4ykDNapBPua2f4nXO3qKnni86O6lgDj5fVNRqbDsD0yy7/XNGDEA==",
       "requires": {
-        "@ethereumjs/common": "^2.3.1",
-        "ethereumjs-util": "^7.0.10"
+        "@ethereumjs/common": "^2.4.0",
+        "ethereumjs-util": "^7.1.0"
       }
     },
     "@ethersproject/abi": {
@@ -36759,9 +36741,9 @@
       }
     },
     "ethereumjs-util": {
-      "version": "7.0.10",
-      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.0.10.tgz",
-      "integrity": "sha512-c/xThw6A+EAnej5Xk5kOzFzyoSnw0WX0tSlZ6pAsfGVvQj3TItaDg9b1+Fz1RJXA+y2YksKwQnuzgt1eY6LKzw==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.1.0.tgz",
+      "integrity": "sha512-kR+vhu++mUDARrsMMhsjjzPduRVAeundLGXucGRHF3B4oEltOUspfgCVco4kckucj3FMlLaZHUl9n7/kdmr6Tw==",
       "requires": {
         "@types/bn.js": "^5.1.0",
         "bn.js": "^5.1.2",
@@ -48195,9 +48177,9 @@
           }
         },
         "tar": {
-          "version": "4.4.13",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.13.tgz",
-          "integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
+          "version": "4.4.15",
+          "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.15.tgz",
+          "integrity": "sha512-ItbufpujXkry7bHH9NpQyTXPbJ72iTlXgkBAYsAjDXk3Ds8t/3NfO5P4xZGy7u+sYuQUbimgzswX4uQIEeNVOA==",
           "requires": {
             "chownr": "^1.1.1",
             "fs-minipass": "^1.2.5",
@@ -48815,11 +48797,6 @@
         "has-symbols": "^1.0.2",
         "which-boxed-primitive": "^1.0.2"
       }
-    },
-    "underscore": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.12.1.tgz",
-      "integrity": "sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw=="
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "1.0.4",
@@ -49561,28 +49538,27 @@
       "integrity": "sha512-npEyJP8jHf3J71t1tRTEtz9FeKp8H2udWJUUq5ykfPhhstr//TUxiYhIEzLNwk4zv2ybAilMn7v7N6Mxmuitmg=="
     },
     "web3": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/web3/-/web3-1.4.0.tgz",
-      "integrity": "sha512-faT3pIX+1tuo+wqmUFQPe10MUGaB1UvRYxw9dmVJFLxaRAIfXErSilOf3jFhSwKbbPNkwG0bTiudCLN9JgeS7A==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/web3/-/web3-1.5.0.tgz",
+      "integrity": "sha512-p6mOU+t11tV5Z0W9ISO2ReZlbB1ICp755ogl3OXOWZ+/oWy12wwnIva+z+ypsZc3P8gaoGaTvEwSfXM9NF164w==",
       "requires": {
-        "web3-bzz": "1.4.0",
-        "web3-core": "1.4.0",
-        "web3-eth": "1.4.0",
-        "web3-eth-personal": "1.4.0",
-        "web3-net": "1.4.0",
-        "web3-shh": "1.4.0",
-        "web3-utils": "1.4.0"
+        "web3-bzz": "1.5.0",
+        "web3-core": "1.5.0",
+        "web3-eth": "1.5.0",
+        "web3-eth-personal": "1.5.0",
+        "web3-net": "1.5.0",
+        "web3-shh": "1.5.0",
+        "web3-utils": "1.5.0"
       }
     },
     "web3-bzz": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.4.0.tgz",
-      "integrity": "sha512-KhXmz8hcfGsqhplB7NrekAeNkG2edHjXV4bL3vnXde8RGMWpabpSNxuwiGv+dv/3nWlrHatH0vGooONYCkP5TA==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.5.0.tgz",
+      "integrity": "sha512-IqlecWpwTMO/O5qa0XZZubQh4GwAtO/CR+e2FQ/7oB5eXQyre3DZ/MYu8s5HCLxCR33Fcqda9q2dbNtm1wSQYw==",
       "requires": {
         "@types/node": "^12.12.6",
         "got": "9.6.0",
-        "swarm-js": "^0.1.40",
-        "underscore": "1.12.1"
+        "swarm-js": "^0.1.40"
       },
       "dependencies": {
         "@sindresorhus/is": {
@@ -49599,9 +49575,9 @@
           }
         },
         "@types/node": {
-          "version": "12.20.15",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.15.tgz",
-          "integrity": "sha512-F6S4Chv4JicJmyrwlDkxUdGNSplsQdGwp1A0AJloEVDirWdZOAiRHhovDlsFkKUrquUXhz1imJhXHsf59auyAg=="
+          "version": "12.20.18",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.18.tgz",
+          "integrity": "sha512-YoTiIwdKxM3VLiY2sM05x4iGuTveYiCcDaUVmo1L5ndrXxPGW/NEoZu+pGcBirziomizcZsnsQoemikKcB2fRA=="
         },
         "cacheable-request": {
           "version": "6.1.0",
@@ -49724,17 +49700,17 @@
       }
     },
     "web3-core": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.4.0.tgz",
-      "integrity": "sha512-VRNMNqwzvPeKIet2l9BMApPHoUv0UqwaZH0lZJhG2RBko42w9Xls+pQwfVNSV16j04t/ehm1aLRV2Sx6lzVfRg==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/web3-core/-/web3-core-1.5.0.tgz",
+      "integrity": "sha512-1o/etaPSK8tFOWTA6df3t9J6ez4epeyzlNmyh/gx8uHasfa16XLKD8//A9T+O/TmvyQAaA4hWAsQcvlRcuaZ8Q==",
       "requires": {
         "@types/bn.js": "^4.11.5",
         "@types/node": "^12.12.6",
         "bignumber.js": "^9.0.0",
-        "web3-core-helpers": "1.4.0",
-        "web3-core-method": "1.4.0",
-        "web3-core-requestmanager": "1.4.0",
-        "web3-utils": "1.4.0"
+        "web3-core-helpers": "1.5.0",
+        "web3-core-method": "1.5.0",
+        "web3-core-requestmanager": "1.5.0",
+        "web3-utils": "1.5.0"
       },
       "dependencies": {
         "@types/bn.js": {
@@ -49746,39 +49722,37 @@
           }
         },
         "@types/node": {
-          "version": "12.20.15",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.15.tgz",
-          "integrity": "sha512-F6S4Chv4JicJmyrwlDkxUdGNSplsQdGwp1A0AJloEVDirWdZOAiRHhovDlsFkKUrquUXhz1imJhXHsf59auyAg=="
+          "version": "12.20.18",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.18.tgz",
+          "integrity": "sha512-YoTiIwdKxM3VLiY2sM05x4iGuTveYiCcDaUVmo1L5ndrXxPGW/NEoZu+pGcBirziomizcZsnsQoemikKcB2fRA=="
         }
       }
     },
     "web3-core-helpers": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.4.0.tgz",
-      "integrity": "sha512-8Ebq0nmRfzw7iPoXbIRHEWOuPh+1cOV3OOEvKm5Od3McZOjja914vdk+DM3MgmbSpDzYJRFM6KoF0+Z/U/1bPw==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/web3-core-helpers/-/web3-core-helpers-1.5.0.tgz",
+      "integrity": "sha512-7s5SrJbG5O0C0Oi9mqKLYchco72djZhk59B7kTla5vUorAxMc99SY7k9BoDgwbFl2dlZon2GtFUEW2RXUNkb1g==",
       "requires": {
-        "underscore": "1.12.1",
-        "web3-eth-iban": "1.4.0",
-        "web3-utils": "1.4.0"
+        "web3-eth-iban": "1.5.0",
+        "web3-utils": "1.5.0"
       }
     },
     "web3-core-method": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.4.0.tgz",
-      "integrity": "sha512-KW9922fEkgKu8zDcJR8Iikg/epsuWMArAUVTipKVwzAI5TVdvOMRgSe/b7IIDRUIeoeXMARmJ+PrAlx+IU2acQ==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.5.0.tgz",
+      "integrity": "sha512-izPhpjbn9jVBjMeFcsU7a5+/nqni9hS5oU+d00HJGTVbp8KV6zplhYw4GjkRqyy6OQzooO8Gx2MMUyRdv5x1wg==",
       "requires": {
         "@ethersproject/transactions": "^5.0.0-beta.135",
-        "underscore": "1.12.1",
-        "web3-core-helpers": "1.4.0",
-        "web3-core-promievent": "1.4.0",
-        "web3-core-subscriptions": "1.4.0",
-        "web3-utils": "1.4.0"
+        "web3-core-helpers": "1.5.0",
+        "web3-core-promievent": "1.5.0",
+        "web3-core-subscriptions": "1.5.0",
+        "web3-utils": "1.5.0"
       }
     },
     "web3-core-promievent": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.4.0.tgz",
-      "integrity": "sha512-YEwko22kcry7lHwbe0k80BrjXCZ+73jMdvZtptRH5k2B+XZ1XtmXwYL1PFIlZy9V0zgZijdg+3GabCnAHjVXAw==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/web3-core-promievent/-/web3-core-promievent-1.5.0.tgz",
+      "integrity": "sha512-7GkbOIMtcp1qN8LRMMmwIhulzEldT+3Mu7ii2WgAcFFKT1yzUl6Gmycf8mmoEKpAuADAQ9Qeyk0PskTR6rTYlQ==",
       "requires": {
         "eventemitter3": "4.0.4"
       },
@@ -49791,26 +49765,24 @@
       }
     },
     "web3-core-requestmanager": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.4.0.tgz",
-      "integrity": "sha512-qIwKJO5T0KkUAIL7y9JRSUkk3+LaCwghdUHK8FzbMvq6R1W9lgCBnccqFGEI76EJjHvsiw4kEKBEXowdB3xenQ==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/web3-core-requestmanager/-/web3-core-requestmanager-1.5.0.tgz",
+      "integrity": "sha512-Sr5T2JuXOAsINJ2tf7Rgi2a+Dy2suBDKT8eMc1pcspPmaBhvTKOQfM9XdsO4yjJKYw6tt/Tagw4GKZm4IOx7mw==",
       "requires": {
-        "underscore": "1.12.1",
         "util": "^0.12.0",
-        "web3-core-helpers": "1.4.0",
-        "web3-providers-http": "1.4.0",
-        "web3-providers-ipc": "1.4.0",
-        "web3-providers-ws": "1.4.0"
+        "web3-core-helpers": "1.5.0",
+        "web3-providers-http": "1.5.0",
+        "web3-providers-ipc": "1.5.0",
+        "web3-providers-ws": "1.5.0"
       }
     },
     "web3-core-subscriptions": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.4.0.tgz",
-      "integrity": "sha512-/UMC9rSLEd0U+h6Qanx6CM29o/cfUyGWgl/HM6O/AIuth9G+34QBuKDa11Gr2Qg6F8Lr9tSFm8QIGVniOx9i5A==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.5.0.tgz",
+      "integrity": "sha512-dx9P1mZvJkQRiYpSo9SvFhYNzy5E9GHeLOc3uqxPaDxKU7Cu9fJnFHo/P6+wfD6ZhGIP23ZLK/uyor5UpdTqDQ==",
       "requires": {
         "eventemitter3": "4.0.4",
-        "underscore": "1.12.1",
-        "web3-core-helpers": "1.4.0"
+        "web3-core-helpers": "1.5.0"
       },
       "dependencies": {
         "eventemitter3": {
@@ -49821,39 +49793,37 @@
       }
     },
     "web3-eth": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.4.0.tgz",
-      "integrity": "sha512-L990eMJeWh4h/Z3M8MJb9HrKq8tqvzdGZ7igdzd6Ba3B/VKgGFAJ/4XIqtLwAJ1Wg5Cj8my60tYY+34c2cLefw==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/web3-eth/-/web3-eth-1.5.0.tgz",
+      "integrity": "sha512-31ni3YliTDYLKuWt8naitZ4Ru86whZlqvz6kFzCaBaCR/EumzA9ejzNbcX9okio9zUtKSHH37Bk0+WogfU9Jqg==",
       "requires": {
-        "underscore": "1.12.1",
-        "web3-core": "1.4.0",
-        "web3-core-helpers": "1.4.0",
-        "web3-core-method": "1.4.0",
-        "web3-core-subscriptions": "1.4.0",
-        "web3-eth-abi": "1.4.0",
-        "web3-eth-accounts": "1.4.0",
-        "web3-eth-contract": "1.4.0",
-        "web3-eth-ens": "1.4.0",
-        "web3-eth-iban": "1.4.0",
-        "web3-eth-personal": "1.4.0",
-        "web3-net": "1.4.0",
-        "web3-utils": "1.4.0"
+        "web3-core": "1.5.0",
+        "web3-core-helpers": "1.5.0",
+        "web3-core-method": "1.5.0",
+        "web3-core-subscriptions": "1.5.0",
+        "web3-eth-abi": "1.5.0",
+        "web3-eth-accounts": "1.5.0",
+        "web3-eth-contract": "1.5.0",
+        "web3-eth-ens": "1.5.0",
+        "web3-eth-iban": "1.5.0",
+        "web3-eth-personal": "1.5.0",
+        "web3-net": "1.5.0",
+        "web3-utils": "1.5.0"
       }
     },
     "web3-eth-abi": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.4.0.tgz",
-      "integrity": "sha512-FtmWipG/dSSkTGFb72JCwky7Jd0PIvd0kGTInWQwIEZlw5qMOYl61WZ9gwfojFHvHF6q1eKncerQr+MRXHO6zg==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.5.0.tgz",
+      "integrity": "sha512-rfT/SvfZY9+SNJRzTHxLFaebQRBhS67tGqUqLxlyy6EsAcEmIs/g4mAUH5atYwPE9bOQeiVoLKLbwJEBIcw86w==",
       "requires": {
         "@ethersproject/abi": "5.0.7",
-        "underscore": "1.12.1",
-        "web3-utils": "1.4.0"
+        "web3-utils": "1.5.0"
       }
     },
     "web3-eth-accounts": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.4.0.tgz",
-      "integrity": "sha512-tETHBvfO3Z7BXZ7HJIwuX7ol6lPefP55X7b4IiX82C1PujHwsxENY7c/3wyxzqKoDyH6zfyEQo17yhxkhsM1oA==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/web3-eth-accounts/-/web3-eth-accounts-1.5.0.tgz",
+      "integrity": "sha512-tqvF2bKECaS6jDux8h1dkdsrfb5SHIVVA6hu2lJmZNlTBqFIq2A8rfOkqcanie6Vh5n5U7Dnc2LUoN9rxgaSSg==",
       "requires": {
         "@ethereumjs/common": "^2.3.0",
         "@ethereumjs/tx": "^3.2.1",
@@ -49861,12 +49831,11 @@
         "eth-lib": "0.2.8",
         "ethereumjs-util": "^7.0.10",
         "scrypt-js": "^3.0.1",
-        "underscore": "1.12.1",
         "uuid": "3.3.2",
-        "web3-core": "1.4.0",
-        "web3-core-helpers": "1.4.0",
-        "web3-core-method": "1.4.0",
-        "web3-utils": "1.4.0"
+        "web3-core": "1.5.0",
+        "web3-core-helpers": "1.5.0",
+        "web3-core-method": "1.5.0",
+        "web3-utils": "1.5.0"
       },
       "dependencies": {
         "eth-lib": {
@@ -49887,19 +49856,18 @@
       }
     },
     "web3-eth-contract": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.4.0.tgz",
-      "integrity": "sha512-GfIhOzfp/ZXKd+1tFEH3ePq0DEsvq9XO5tOsI0REDtEYUj2GNxO5e/x/Fhekk7iLZ7xAqSzDMweFruDQ1fxn0A==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.5.0.tgz",
+      "integrity": "sha512-v4laiJRzdcoDwvqaMCzJH1BUosbTVsd01Qp+9v05Q94KycjkdeahPRXX6PEcUNW/ZF8N006iExUweGjajTZnTA==",
       "requires": {
         "@types/bn.js": "^4.11.5",
-        "underscore": "1.12.1",
-        "web3-core": "1.4.0",
-        "web3-core-helpers": "1.4.0",
-        "web3-core-method": "1.4.0",
-        "web3-core-promievent": "1.4.0",
-        "web3-core-subscriptions": "1.4.0",
-        "web3-eth-abi": "1.4.0",
-        "web3-utils": "1.4.0"
+        "web3-core": "1.5.0",
+        "web3-core-helpers": "1.5.0",
+        "web3-core-method": "1.5.0",
+        "web3-core-promievent": "1.5.0",
+        "web3-core-subscriptions": "1.5.0",
+        "web3-eth-abi": "1.5.0",
+        "web3-utils": "1.5.0"
       },
       "dependencies": {
         "@types/bn.js": {
@@ -49913,28 +49881,27 @@
       }
     },
     "web3-eth-ens": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.4.0.tgz",
-      "integrity": "sha512-jR1KorjU1erpYFpFzsMXAWZnHhqUqWPBq/4+BGVj7/pJ43+A3mrE1eB0zl91Dwc1RTNwOhB02iOj1c9OlpGr3g==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/web3-eth-ens/-/web3-eth-ens-1.5.0.tgz",
+      "integrity": "sha512-NiaGfOnsCqP+3hOCeP3Q9IrlV/1ZCDiv8VmN1yF5Ya6n6YeO4TJU9MKP8i5038RFETjLIfGtXr5fthbsob30hA==",
       "requires": {
         "content-hash": "^2.5.2",
         "eth-ens-namehash": "2.0.8",
-        "underscore": "1.12.1",
-        "web3-core": "1.4.0",
-        "web3-core-helpers": "1.4.0",
-        "web3-core-promievent": "1.4.0",
-        "web3-eth-abi": "1.4.0",
-        "web3-eth-contract": "1.4.0",
-        "web3-utils": "1.4.0"
+        "web3-core": "1.5.0",
+        "web3-core-helpers": "1.5.0",
+        "web3-core-promievent": "1.5.0",
+        "web3-eth-abi": "1.5.0",
+        "web3-eth-contract": "1.5.0",
+        "web3-utils": "1.5.0"
       }
     },
     "web3-eth-iban": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.4.0.tgz",
-      "integrity": "sha512-YNx748VzwiBe0gvtZjvU9BQsooZ9s9sAlmiDWJOMcvMbUTDhC7SvxA7vV/vrnOxL6oGHRh0U/azsYNxxlKiTBw==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.5.0.tgz",
+      "integrity": "sha512-cFfiPA8xs4lemMJjDb9KfXzPvs6rBrRl8y4rgvh/JWlZZgKolzo7KLXq4NR3oFd/C81s0Lslvz2st1EREp5CNA==",
       "requires": {
         "bn.js": "^4.11.9",
-        "web3-utils": "1.4.0"
+        "web3-utils": "1.5.0"
       },
       "dependencies": {
         "bn.js": {
@@ -49945,33 +49912,33 @@
       }
     },
     "web3-eth-personal": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.4.0.tgz",
-      "integrity": "sha512-8Ip6xZ8plmWqAD4ESbKUIPVV9gfTAFFm0ff1FQIw9I9kYvFlBIPzukvm852w2SftGem+/iRH+2+2mK7HvuKXZQ==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/web3-eth-personal/-/web3-eth-personal-1.5.0.tgz",
+      "integrity": "sha512-FYBrzMS6q/df8ud1kAN1p6lqdP/pd0szogcuyrVyi++bFQiovnR+QosudFsbn/aAZPDHOEh0UV4P3KVKbLqw9g==",
       "requires": {
         "@types/node": "^12.12.6",
-        "web3-core": "1.4.0",
-        "web3-core-helpers": "1.4.0",
-        "web3-core-method": "1.4.0",
-        "web3-net": "1.4.0",
-        "web3-utils": "1.4.0"
+        "web3-core": "1.5.0",
+        "web3-core-helpers": "1.5.0",
+        "web3-core-method": "1.5.0",
+        "web3-net": "1.5.0",
+        "web3-utils": "1.5.0"
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.20.15",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.15.tgz",
-          "integrity": "sha512-F6S4Chv4JicJmyrwlDkxUdGNSplsQdGwp1A0AJloEVDirWdZOAiRHhovDlsFkKUrquUXhz1imJhXHsf59auyAg=="
+          "version": "12.20.18",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.18.tgz",
+          "integrity": "sha512-YoTiIwdKxM3VLiY2sM05x4iGuTveYiCcDaUVmo1L5ndrXxPGW/NEoZu+pGcBirziomizcZsnsQoemikKcB2fRA=="
         }
       }
     },
     "web3-net": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.4.0.tgz",
-      "integrity": "sha512-41WkKobL+KnKC0CY0RZ1KhMMyR/hMFGlbHZQac4KtB7ro1UdXeK+RiYX+GzSr1h7j9Dj+dQZqyBs70cxmL9cPQ==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/web3-net/-/web3-net-1.5.0.tgz",
+      "integrity": "sha512-oGgEtO2fRtJjAp0K1/fvH247MeeDemFL+5tF+PxII9b/gBxnVe+MzP+oNLr4dTrweromjv34tioR3kUgsqwCWg==",
       "requires": {
-        "web3-core": "1.4.0",
-        "web3-core-method": "1.4.0",
-        "web3-utils": "1.4.0"
+        "web3-core": "1.5.0",
+        "web3-core-method": "1.5.0",
+        "web3-utils": "1.5.0"
       }
     },
     "web3-provider-engine": {
@@ -50074,32 +50041,30 @@
       }
     },
     "web3-providers-http": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.4.0.tgz",
-      "integrity": "sha512-A9nLF4XGZfDb1KYYuKRwHY1H90Ee/0I0CqQQEELI0yuY9eca50qdCHEg3sJhvqBIG44JCm83amOGxR8wi+76tQ==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/web3-providers-http/-/web3-providers-http-1.5.0.tgz",
+      "integrity": "sha512-y1RuxsCGrWdsIUyuZBEN+3F8trl3bDZNajwLS2KYBGlB99sWYZHPmvbAsBpaW1d/I12W0fQiWOVzp63L7KPTow==",
       "requires": {
-        "web3-core-helpers": "1.4.0",
+        "web3-core-helpers": "1.5.0",
         "xhr2-cookies": "1.1.0"
       }
     },
     "web3-providers-ipc": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.4.0.tgz",
-      "integrity": "sha512-ul/tSNUI5anhdBGBV+FWFH9EJgO73/G21haFDEXvTnSJQa9/byj401H/E2Xd8BXGk+2XB+CCGLZBiuAjhhhtTA==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/web3-providers-ipc/-/web3-providers-ipc-1.5.0.tgz",
+      "integrity": "sha512-Hda9wlOaIJC9/qMOVkayK+fbBHDZBmPcoL7TfjQX7hrtZn8V3+gR27ciyRXmuW7QD3hDg7CJfe5uRK8brh3nSA==",
       "requires": {
         "oboe": "2.1.5",
-        "underscore": "1.12.1",
-        "web3-core-helpers": "1.4.0"
+        "web3-core-helpers": "1.5.0"
       }
     },
     "web3-providers-ws": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.4.0.tgz",
-      "integrity": "sha512-E5XfF58RLXuCtGiMSXxXEtjceCfPli+I4MDYCKx/J/bDJ6qvLUM2OnnGEmE7pq1Z03h0xh1ZezaB/qoweK3ZIQ==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/web3-providers-ws/-/web3-providers-ws-1.5.0.tgz",
+      "integrity": "sha512-TCwOhu5WbuQCSUoar+U+7N1NqI4A6MlcdZqsC7AhTogYYtnXOPRWfiHMZtUP7Qw50GKJ37FIH3YDItcHTNHd6A==",
       "requires": {
         "eventemitter3": "4.0.4",
-        "underscore": "1.12.1",
-        "web3-core-helpers": "1.4.0",
+        "web3-core-helpers": "1.5.0",
         "websocket": "^1.0.32"
       },
       "dependencies": {
@@ -50111,20 +50076,20 @@
       }
     },
     "web3-shh": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.4.0.tgz",
-      "integrity": "sha512-OZMkMgo+VZnu1ErhIFXW+5ExnPKQg9v8/2DHGVtNEwuC5OHYuAEF5U7MQgbxYJYwbRmxQCt/hA3VwKjnkbmSAA==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/web3-shh/-/web3-shh-1.5.0.tgz",
+      "integrity": "sha512-TwpcxXNh+fBnyRcCPPqVqaCB4IjSpVL2/5OR2WwCnZwejs1ife+pej8DYVZWm0m1tSzIDRTdNbsJf/DN0cAxYQ==",
       "requires": {
-        "web3-core": "1.4.0",
-        "web3-core-method": "1.4.0",
-        "web3-core-subscriptions": "1.4.0",
-        "web3-net": "1.4.0"
+        "web3-core": "1.5.0",
+        "web3-core-method": "1.5.0",
+        "web3-core-subscriptions": "1.5.0",
+        "web3-net": "1.5.0"
       }
     },
     "web3-utils": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.4.0.tgz",
-      "integrity": "sha512-b8mEhwh/J928Xk+SQFjtqrR2EGPhpknWLcIt9aCpVPVRXiqjUGo/kpOHKz0azu9c6/onEJ9tWXZt0cVjmH0N5Q==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.5.0.tgz",
+      "integrity": "sha512-hNyw7Oxi6TM3ivXmv4hK5Cvyi9ML3UoKtcCYvLF9woPWh5v2dwCCVO1U3Iq5HHK7Dqq28t1d4CxWHqUfOfAkgg==",
       "requires": {
         "bn.js": "^4.11.9",
         "eth-lib": "0.2.8",
@@ -50132,7 +50097,6 @@
         "ethjs-unit": "0.1.6",
         "number-to-bn": "1.7.0",
         "randombytes": "^2.1.0",
-        "underscore": "1.12.1",
         "utf8": "3.0.0"
       },
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "redux": "^4.1.0",
     "redux-thunk": "^2.3.0",
     "web-vitals": "^2.1.0",
-    "web3": "^1.3.6",
+    "web3": "^1.5.0",
     "web3modal": "^1.9.3"
   },
   "devDependencies": {


### PR DESCRIPTION
Fixes #440 

🧹 **Chores done**
 
 - Upgrades `web3@1.5.0`. This release provides new options available as a result of the London hardfork update.
