### PR TITLE
Fix walletConnect QR for desktop

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,6 @@
         "ethers": "^5.4.0",
         "markdown-to-jsx": "^7.1.2",
         "react": "^17.0.1",
-        "react-device-detect": "^1.17.0",
         "react-dom": "^17.0.2",
         "react-helmet": "^6.1.0",
         "react-hook-form": "^6.15.4",
@@ -19749,18 +19748,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/react-device-detect": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/react-device-detect/-/react-device-detect-1.17.0.tgz",
-      "integrity": "sha512-bBblIStwpHmoS281JFIVqeimcN3LhpoP5YKDWzxQdBIUP8S2xPvHDgizLDhUq2ScguLfVPmwfF5y268EEQR60w==",
-      "dependencies": {
-        "ua-parser-js": "^0.7.24"
-      },
-      "peerDependencies": {
-        "react": ">= 0.14.0 < 18.0.0",
-        "react-dom": ">= 0.14.0 < 18.0.0"
-      }
-    },
     "node_modules/react-dom": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
@@ -25302,24 +25289,6 @@
       },
       "engines": {
         "node": ">=4.2.0"
-      }
-    },
-    "node_modules/ua-parser-js": {
-      "version": "0.7.28",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.28.tgz",
-      "integrity": "sha512-6Gurc1n//gjp9eQNXjD9O3M/sMwVtN5S8Lv9bvOYBfKfDNiIIhqiyi01vMBO45u4zkDE420w/e0se7Vs+sIg+g==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/ua-parser-js"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/faisalman"
-        }
-      ],
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/ultron": {
@@ -44090,14 +44059,6 @@
         }
       }
     },
-    "react-device-detect": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/react-device-detect/-/react-device-detect-1.17.0.tgz",
-      "integrity": "sha512-bBblIStwpHmoS281JFIVqeimcN3LhpoP5YKDWzxQdBIUP8S2xPvHDgizLDhUq2ScguLfVPmwfF5y268EEQR60w==",
-      "requires": {
-        "ua-parser-js": "^0.7.24"
-      }
-    },
     "react-dom": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
@@ -48497,11 +48458,6 @@
       "version": "4.3.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
       "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA=="
-    },
-    "ua-parser-js": {
-      "version": "0.7.28",
-      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.28.tgz",
-      "integrity": "sha512-6Gurc1n//gjp9eQNXjD9O3M/sMwVtN5S8Lv9bvOYBfKfDNiIIhqiyi01vMBO45u4zkDE420w/e0se7Vs+sIg+g=="
     },
     "ultron": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "ethers": "^5.4.0",
     "markdown-to-jsx": "^7.1.2",
     "react": "^17.0.1",
-    "react-device-detect": "^1.17.0",
     "react-dom": "^17.0.2",
     "react-helmet": "^6.1.0",
     "react-hook-form": "^6.15.4",

--- a/src/components/web3/ConnectWalletModal.tsx
+++ b/src/components/web3/ConnectWalletModal.tsx
@@ -1,4 +1,4 @@
-import {isMobile} from 'react-device-detect';
+import {isMobile} from '@walletconnect/browser-utils';
 import {Link, useLocation} from 'react-router-dom';
 import {useEffect} from 'react';
 import {usePrevious} from 'react-use';
@@ -80,7 +80,7 @@ export default function ConnectWalletModal(
 
   const displayOptions: JSX.Element[] = Object.entries(providerOptions)
     // If mobile, filter-out `"injected"`
-    .filter(([type]) => (isMobile ? type !== 'injected' : true))
+    .filter(([type]) => (isMobile() ? type !== 'injected' : true))
     .map((provider: Record<number, any>) => {
       const isButtonDisabled: boolean =
         isChainGanache && provider[0] === 'walletconnect';

--- a/src/components/web3/ConnectWalletModal.unit.test.tsx
+++ b/src/components/web3/ConnectWalletModal.unit.test.tsx
@@ -1,4 +1,3 @@
-import {formatBytes32String} from 'ethers/lib/utils';
 import {render, screen, waitFor} from '@testing-library/react';
 import {Store} from 'redux';
 import {useDispatch, useSelector} from 'react-redux';
@@ -10,12 +9,12 @@ import {
   setConnectedMember,
 } from '../../store/actions';
 import {CHAINS} from '../../config';
+import {DEFAULT_ETH_ADDRESS} from '../../test/helpers';
 import {StoreState} from '../../store/types';
+import {useEffect} from 'react';
+import {useHistory, useLocation} from 'react-router';
 import ConnectWalletModal from './ConnectWalletModal';
 import Wrapper from '../../test/Wrapper';
-import {useHistory, useLocation} from 'react-router';
-import {DEFAULT_ETH_ADDRESS} from '../../test/helpers';
-import {useEffect} from 'react';
 
 describe('ConnectWalletModal unit tests', () => {
   test('should open modal', async () => {
@@ -608,13 +607,12 @@ describe('ConnectWalletModal unit tests', () => {
   });
 
   test('can remove `"injected"` provider option when device is mobile', async () => {
-    // Mock default chain so we can click `"walletconnect"`
-    const reactDeviceDetect = await import('react-device-detect');
+    // Mock @walletconnect's `isMobile: () => boolean`
+    const walletConnectUtils = await import('@walletconnect/browser-utils');
 
-    const reactDeviceDetectIsMobile = reactDeviceDetect.isMobile;
-
-    // Set as mobile
-    reactDeviceDetect.isMobile = true;
+    const isMobileMock = jest
+      .spyOn(walletConnectUtils, 'isMobile')
+      .mockImplementation(() => true);
 
     let store: Store;
 
@@ -660,6 +658,6 @@ describe('ConnectWalletModal unit tests', () => {
     });
 
     // Reset to original value
-    reactDeviceDetect.isMobile = reactDeviceDetectIsMobile;
+    isMobileMock.mockRestore();
   });
 });

--- a/src/components/web3/Web3ModalButton.tsx
+++ b/src/components/web3/Web3ModalButton.tsx
@@ -1,4 +1,4 @@
-import {isMobile} from 'react-device-detect';
+import {isMobile} from '@walletconnect/browser-utils';
 import {useDispatch} from 'react-redux';
 
 import {connectModalOpen} from '../../store/actions';
@@ -10,7 +10,7 @@ import {WalletIcon} from './';
 type CustomWalletTextProps = {
   account: ReturnType<typeof useWeb3Modal>['account'];
   connected: ReturnType<typeof useWeb3Modal>['connected'];
-  isMobile: typeof isMobile;
+  isMobile: ReturnType<typeof isMobile>;
 };
 
 type ConnectWalletButtonProps = {
@@ -50,7 +50,7 @@ export default function ConnectWalletButton({
   function getWalletText(): string {
     if (customWalletText) {
       return typeof customWalletText === 'function'
-        ? customWalletText({account, connected, isMobile})
+        ? customWalletText({account, connected, isMobile: isMobile()})
         : customWalletText;
     }
 

--- a/src/components/web3/Web3ModalManager.tsx
+++ b/src/components/web3/Web3ModalManager.tsx
@@ -1,6 +1,6 @@
 import {createContext, useEffect, useRef, useState} from 'react';
 import Web3 from 'web3';
-import Web3Modal from 'web3modal';
+import Web3Modal, {IProviderOptions} from 'web3modal';
 
 import useWeb3ModalManager, {
   DefaultTheme,
@@ -24,7 +24,7 @@ type Web3ModalProviderArguments = {
   onBeforeConnect?: Parameters<
     typeof useWeb3ModalManager
   >[0]['onBeforeConnect'];
-  providerOptions: Record<string, any>; // required
+  providerOptions: IProviderOptions; // required
 };
 
 type Web3ModalManagerProps = {
@@ -40,7 +40,7 @@ export type Web3ModalContextValue = {
   initialCachedConnectorCheckStatus: AsyncStatus | undefined;
   networkId: number | undefined;
   provider: any;
-  providerOptions: Record<string, any>;
+  providerOptions: IProviderOptions;
   web3Instance: Web3 | undefined;
   web3Modal: Web3Modal | undefined;
 };

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,4 +1,6 @@
 import {config as dotenvConfig} from 'dotenv';
+import {IProviderOptions} from 'web3modal';
+import {isMobile} from '@walletconnect/browser-utils';
 import {resolve} from 'path';
 import WalletConnectProvider from '@walletconnect/web3-provider';
 
@@ -121,7 +123,7 @@ export const ETHEREUM_PROVIDER_URL: string = INFURA_WS_URLS[DEFAULT_CHAIN]
  * The built-in web browser provider (only one can exist at a time),
  * MetaMask, Brave or Opera is added automatically by Web3modal
  */
-export const WALLETCONNECT_PROVIDER_OPTIONS = {
+export const WALLETCONNECT_PROVIDER_OPTIONS: IProviderOptions = {
   // Injected providers
   injected: {
     display: {
@@ -140,7 +142,9 @@ export const WALLETCONNECT_PROVIDER_OPTIONS = {
     options: {
       infuraId: INFURA_PROJECT_ID, // required
       qrcodeModalOptions: {
-        mobileLinks: ['rainbow', 'metamask', 'argent', 'trust'],
+        mobileLinks: isMobile()
+          ? ['rainbow', 'metamask', 'argent', 'trust']
+          : [],
       },
     },
   },


### PR DESCRIPTION
✨ **Updates**

 - Code where `react-device-detect` was used; fixes tests.

🐞 **Bugs squashed**

 - The new version of `@walletconnect/web3-provider` made our WalletConnect modal regress. It now includes in the `Modal` component a toggle between QR code <--> "Desktop". The mobile links we were using in the options were not compatible with the `desktop` platform.

⛔️ **Removes**

 - `react-device-detect` for now, as we don't need the package since `@walletconnect/browser-utils` has it already

