### PR TITLE
Disable voting for members who did not hold membership as of snapshot

### DIFF
--- a/src/components/governance/GovernanceActions.tsx
+++ b/src/components/governance/GovernanceActions.tsx
@@ -53,7 +53,9 @@ export function GovernanceActions(props: GovernanceActionsProps) {
    */
 
   const votingResult = offchainVotingResults[0]?.[1];
-  const {hasVotingEnded, hasVotingStarted} = votingPeriodData;
+
+  const {hasVotingEnded, hasVotingStarted, votingStartEndInitReady} =
+    votingPeriodData;
 
   /**
    * Functions
@@ -78,7 +80,7 @@ export function GovernanceActions(props: GovernanceActionsProps) {
         votingResult={votingResult}
       />
 
-      {hasVotingStarted && !hasVotingEnded && (
+      {votingStartEndInitReady && hasVotingStarted && !hasVotingEnded && (
         <OffchainVotingAction proposal={proposal} />
       )}
     </>

--- a/src/components/governance/GovernanceActions.unit.test.tsx
+++ b/src/components/governance/GovernanceActions.unit.test.tsx
@@ -77,7 +77,7 @@ describe('GovernanceActions unit tests', () => {
             metadata: {},
             start: nowSeconds() - 10,
             // Voting ended
-            end: nowSeconds() - 5,
+            end: nowSeconds() + 3,
           },
           version: '',
           timestamp: '',
@@ -136,9 +136,7 @@ describe('GovernanceActions unit tests', () => {
 
     await waitFor(() => {
       // SVG
-      expect(
-        screen.getByLabelText(/^counting down until voting ends$/i)
-      ).toBeInTheDocument();
+      expect(screen.getByLabelText(/^voting status$/i)).toBeInTheDocument();
 
       // Voting %
       expect(screen.getByText(/^2%$/i)).toBeInTheDocument();
@@ -155,68 +153,22 @@ describe('GovernanceActions unit tests', () => {
     });
 
     // Voting end
-    await waitFor(() => {
-      expect(screen.getByText(/^approved$/i)).toBeInTheDocument();
+    await waitFor(
+      () => {
+        // SVG
+        expect(screen.getByLabelText(/^proposal status$/i)).toBeInTheDocument();
 
-      // Voting buttons should be hidden
-      expect(() => screen.getByRole('button', {name: /^vote yes$/i})).toThrow();
-      expect(() => screen.getByRole('button', {name: /^vote no$/i})).toThrow();
-    });
-  });
+        expect(screen.getByText(/^approved$/i)).toBeInTheDocument();
 
-  test('should return correct content after voting end', async () => {
-    const proposal = fakeSnapshotProposal();
-
-    let mockWeb3Provider: FakeHttpProvider;
-    let web3Instance: Web3;
-
-    render(
-      <Wrapper
-        useInit
-        useWallet
-        getProps={(p) => {
-          mockWeb3Provider = p.mockWeb3Provider;
-          web3Instance = p.web3Instance;
-        }}>
-        <GovernanceActions proposal={proposal} />
-      </Wrapper>
+        // Voting buttons should be hidden
+        expect(() =>
+          screen.getByRole('button', {name: /^vote yes$/i})
+        ).toThrow();
+        expect(() =>
+          screen.getByRole('button', {name: /^vote no$/i})
+        ).toThrow();
+      },
+      {timeout: 5000}
     );
-
-    await waitFor(() => {
-      // Inject mocked units result
-      mockWeb3Provider.injectResult(
-        web3Instance.eth.abi.encodeParameters(
-          ['uint256', 'bytes[]'],
-          [
-            0,
-            [
-              // Total units
-              web3Instance.eth.abi.encodeParameter('uint256', '10000000'),
-              // Units for "yes" voter
-              web3Instance.eth.abi.encodeParameter('uint256', '200000'),
-              // Units for "no" voter
-              web3Instance.eth.abi.encodeParameter('uint256', '100000'),
-            ],
-          ]
-        )
-      );
-    });
-
-    await waitFor(() => {
-      // SVG
-      expect(
-        screen.getByLabelText(/^counting down until voting ends$/i)
-      ).toBeInTheDocument();
-
-      // Voting %
-      expect(screen.getByText(/^2%$/i)).toBeInTheDocument();
-      expect(screen.getByText(/^1%$/i)).toBeInTheDocument();
-
-      expect(screen.getByText(/^approved$/i)).toBeInTheDocument();
-
-      // Voting buttons should be hidden
-      expect(() => screen.getByRole('button', {name: /^vote yes$/i})).toThrow();
-      expect(() => screen.getByRole('button', {name: /^vote no$/i})).toThrow();
-    });
   });
 });

--- a/src/components/governance/GovernanceActions.unit.test.tsx
+++ b/src/components/governance/GovernanceActions.unit.test.tsx
@@ -136,7 +136,7 @@ describe('GovernanceActions unit tests', () => {
 
     await waitFor(() => {
       // SVG
-      expect(screen.getByLabelText(/^voting status$/i)).toBeInTheDocument();
+      expect(screen.getByLabelText(/^proposal status$/i)).toBeInTheDocument();
 
       // Voting %
       expect(screen.getByText(/^2%$/i)).toBeInTheDocument();

--- a/src/components/governance/GovernanceProposalsList.tsx
+++ b/src/components/governance/GovernanceProposalsList.tsx
@@ -142,19 +142,20 @@ export default function GovernanceProposalsList(
           normalizeString(p.snapshotProposal?.idInSnapshot || '')
       )?.[1];
 
-      if (!offchainResult) return;
-
-      const didPass = didPassSimpleMajority(offchainResult);
+      // Did the vote pass by a simple majority?
+      const didPassSimpleMajority: boolean = offchainResult
+        ? offchainResult.Yes.units > offchainResult.No.units
+        : false;
 
       // passed proposal
-      if (didPass) {
+      if (didPassSimpleMajority) {
         filteredProposalsToSet.passedProposals.push(p);
 
         return;
       }
 
       // failed proposal
-      if (!didPass) {
+      if (!didPassSimpleMajority) {
         filteredProposalsToSet.failedProposals.push(p);
 
         return;
@@ -170,10 +171,6 @@ export default function GovernanceProposalsList(
   /**
    * Functions
    */
-
-  function didPassSimpleMajority(offchainVoteResult: VotingResult): boolean {
-    return offchainVoteResult.Yes.units > offchainVoteResult.No.units;
-  }
 
   function renderProposalCards(
     proposals: ProposalData[]

--- a/src/components/governance/GovernanceProposalsList.unit.test.tsx
+++ b/src/components/governance/GovernanceProposalsList.unit.test.tsx
@@ -12,13 +12,12 @@ import {rest, server} from '../../test/server';
 import {SNAPSHOT_HUB_API_URL} from '../../config';
 import {snapshotAPIProposalResponse} from '../../test/restResponses';
 import GovernanceProposalsList from './GovernanceProposalsList';
-import MulticallABI from '../../truffle-contracts/Multicall.json';
 import Wrapper from '../../test/Wrapper';
 
 describe('GovernanceProposalsList unit tests', () => {
   const defaultProposalVotes: SnapshotProposalResponseData['votes'] = [
     {
-      DEFAULT_ETH_ADDRESS: {
+      [DEFAULT_ETH_ADDRESS]: {
         address: DEFAULT_ETH_ADDRESS,
         msg: {
           version: '0.2.0',

--- a/src/components/proposals/Proposals.tsx
+++ b/src/components/proposals/Proposals.tsx
@@ -195,10 +195,10 @@ export default function Proposals(props: ProposalsProps): JSX.Element {
           normalizeString(p.snapshotProposal?.idInDAO || '')
       )?.[1];
 
-      if (!offchainResult) return;
-
       // Did the vote pass by a simple majority?
-      const didPass = offchainResult.Yes.units > offchainResult.No.units;
+      const didPassSimpleMajority: boolean = offchainResult
+        ? offchainResult.Yes.units > offchainResult.No.units
+        : false;
 
       /**
        * Voting proposal: voting has ended, off-chain result was not submitted,
@@ -208,12 +208,13 @@ export default function Proposals(props: ProposalsProps): JSX.Element {
        * @note For now, we can assume across all adapters that if the vote did
        * not pass then the result does not need to be submitted (proposal would
        * fall back to "failed" logic).
+       *
        * @note Should be placed before "failed" logic.
        */
       if (
         offchainResultNotYetSubmitted &&
         noSnapshotVotes === false &&
-        didPass
+        didPassSimpleMajority
       ) {
         filteredProposalsToSet.votingProposals.push(p);
 
@@ -248,7 +249,7 @@ export default function Proposals(props: ProposalsProps): JSX.Element {
       if (
         voteState !== undefined &&
         offchainResultNotYetSubmitted &&
-        !didPass
+        !didPassSimpleMajority
       ) {
         filteredProposalsToSet.failedProposals.push(p);
 

--- a/src/components/proposals/Proposals.unit.test.tsx
+++ b/src/components/proposals/Proposals.unit.test.tsx
@@ -52,7 +52,7 @@ describe('ProposalCard unit tests', () => {
 
   const defaultProposalVotes: SnapshotProposalResponseData['votes'] = [
     {
-      DEFAULT_ETH_ADDRESS: {
+      [DEFAULT_ETH_ADDRESS]: {
         address: DEFAULT_ETH_ADDRESS,
         msg: {
           version: '0.2.0',

--- a/src/components/proposals/hooks/useOffchainVotingResults.ts
+++ b/src/components/proposals/hooks/useOffchainVotingResults.ts
@@ -120,7 +120,7 @@ export function useOffchainVotingResults(
         ];
       });
 
-      if (!voterEntries) return;
+      if (!voterEntries || !voterEntries.length) return;
 
       // Dedupe any duplicate addresses to be safe.
       const voterAddressesAndChoices = Object.entries(

--- a/src/components/proposals/voting/OffchainOpRollupVotingSubmitResultAction.unit.test.tsx
+++ b/src/components/proposals/voting/OffchainOpRollupVotingSubmitResultAction.unit.test.tsx
@@ -28,7 +28,7 @@ import Wrapper from '../../../test/Wrapper';
 
 const defaultProposalVotes: SnapshotProposalResponseData['votes'] = [
   {
-    DEFAULT_ETH_ADDRESS: {
+    [DEFAULT_ETH_ADDRESS]: {
       address: DEFAULT_ETH_ADDRESS,
       msg: {
         version: '0.2.0',

--- a/src/components/proposals/voting/OffchainVotingAction.tsx
+++ b/src/components/proposals/voting/OffchainVotingAction.tsx
@@ -234,11 +234,6 @@ export function OffchainVotingAction(
         voteProgress={voteChoiceProgress}
       />
 
-      <ErrorMessageWithDetails
-        error={error}
-        renderText="Something went wrong"
-      />
-
       {isDisabled && (
         <button
           className="button--help-centered"
@@ -246,6 +241,11 @@ export function OffchainVotingAction(
           Why is voting disabled?
         </button>
       )}
+
+      <ErrorMessageWithDetails
+        error={error}
+        renderText="Something went wrong"
+      />
 
       <WhyDisabledModal title="Why is voting disabled?" />
     </>

--- a/src/components/proposals/voting/OffchainVotingAction.tsx
+++ b/src/components/proposals/voting/OffchainVotingAction.tsx
@@ -1,15 +1,19 @@
 import {useEffect, useRef, useState} from 'react';
+import {useSelector} from 'react-redux';
+import {VoteChoices} from '@openlaw/snapshot-js-erc712';
 
-import {truncateEthAddress} from '../../../util/helpers';
+import {
+  useMemberActionDisabled,
+  useMemberUnitsAtSnapshot,
+} from '../../../hooks';
+import {AsyncStatus} from '../../../util/types';
 import {ContractAdapterNames, Web3TxStatus} from '../../web3/types';
 import {getVoteChosen} from '../helpers';
 import {ProposalData} from '../types';
 import {StoreState} from '../../../store/types';
-import {useMemberActionDisabled} from '../../../hooks';
-import {useSelector} from 'react-redux';
+import {truncateEthAddress} from '../../../util/helpers';
 import {useSignAndSendVote} from '../hooks';
 import {useWeb3Modal} from '../../web3/hooks';
-import {VoteChoices} from '@openlaw/snapshot-js-erc712';
 import {VotingActionButtons} from '.';
 import ErrorMessageWithDetails from '../../common/ErrorMessageWithDetails';
 
@@ -21,7 +25,11 @@ type OffchainVotingActionProps = {
 type VotingDisabledReasons = {
   addressIsDelegatedMessage: string;
   alreadyVotedMessage: string;
+  noMembershipAtSnapshotMessage: string;
+  undeterminedMembershipAtSnapshotMessage: string;
 };
+
+const {FULFILLED, REJECTED} = AsyncStatus;
 
 const getDelegatedAddressMessage = (a: string) =>
   `Your member address is delegated to ${truncateEthAddress(
@@ -39,7 +47,10 @@ const getDelegatedAddressMessage = (a: string) =>
 export function OffchainVotingAction(
   props: OffchainVotingActionProps
 ): JSX.Element | null {
-  const {adapterName, proposal} = props;
+  const {
+    adapterName,
+    proposal: {snapshotProposal, refetchProposalOrDraft},
+  } = props;
 
   /**
    * State
@@ -55,6 +66,8 @@ export function OffchainVotingAction(
   const votingDisabledReasonsRef = useRef<VotingDisabledReasons>({
     addressIsDelegatedMessage: '',
     alreadyVotedMessage: '',
+    noMembershipAtSnapshotMessage: '',
+    undeterminedMembershipAtSnapshotMessage: '',
   });
 
   /**
@@ -69,16 +82,18 @@ export function OffchainVotingAction(
     (s: StoreState) => s.connectedMember?.isAddressDelegated
   );
 
+  const memberAddress = useSelector(
+    (s: StoreState) => s.connectedMember?.memberAddress
+  );
+
   /**
    * Our hooks
    */
 
   const {account} = useWeb3Modal();
   const {signAndSendVote, voteDataStatus} = useSignAndSendVote();
-  const voteChosen = getVoteChosen(
-    proposal.snapshotProposal?.votes,
-    account || ''
-  );
+  const voteChosen = getVoteChosen(snapshotProposal?.votes, account || '');
+
   const {
     isDisabled,
     openWhyDisabledModal,
@@ -86,13 +101,21 @@ export function OffchainVotingAction(
     WhyDisabledModal,
   } = useMemberActionDisabled();
 
+  const {
+    hasMembershipAtSnapshot,
+    memberUnitsAtSnapshotError,
+    memberUnitsAtSnapshotStatus,
+  } = useMemberUnitsAtSnapshot(
+    memberAddress,
+    snapshotProposal?.msg.payload.snapshot
+  );
+
   /**
    * Variables
    */
 
-  const proposalHash: string = proposal.snapshotProposal?.idInDAO || '';
-  const snapshotProposalId: string =
-    proposal.snapshotProposal?.idInSnapshot || '';
+  const proposalHash: string = snapshotProposal?.idInDAO || '';
+  const snapshotProposalId: string = snapshotProposal?.idInSnapshot || '';
 
   const isInProcess =
     voteDataStatus === Web3TxStatus.AWAITING_CONFIRM ||
@@ -108,6 +131,8 @@ export function OffchainVotingAction(
     ? voteChoiceClicked
     : undefined;
 
+  const error: Error | undefined = submitError || memberUnitsAtSnapshotError;
+
   /**
    * Effects
    */
@@ -117,28 +142,41 @@ export function OffchainVotingAction(
 
     // Reason: address is delegated
     if (delegateAddress) {
-      // Set or unset
-      const addressIsDelegatedMessage = isAddressDelegated
-        ? getDelegatedAddressMessage(delegateAddress)
-        : '';
-
-      votingDisabledReasonsRef.current = {
-        ...votingDisabledReasonsRef.current,
-        addressIsDelegatedMessage,
-      };
+      setDisabledReasonHelper(
+        'addressIsDelegatedMessage',
+        isAddressDelegated ? getDelegatedAddressMessage(delegateAddress) : ''
+      );
     }
 
     // Reason: already voted
-    votingDisabledReasonsRef.current = {
-      ...votingDisabledReasonsRef.current,
-      alreadyVotedMessage: voteChosen ? 'You have already voted.' : '',
-    };
+    setDisabledReasonHelper(
+      'alreadyVotedMessage',
+      voteChosen ? 'You have already voted.' : ''
+    );
+
+    // Reason: did not hold membership by snapshot
+    setDisabledReasonHelper(
+      'noMembershipAtSnapshotMessage',
+      !hasMembershipAtSnapshot && memberUnitsAtSnapshotStatus === FULFILLED
+        ? 'You were not a member when the proposal was sponsored.'
+        : ''
+    );
+
+    // Reason: cannot determine membership by snapshot
+    setDisabledReasonHelper(
+      'undeterminedMembershipAtSnapshotMessage',
+      memberUnitsAtSnapshotStatus === REJECTED
+        ? 'Your membership status at the time this proposal was sponsored cannot be determined.'
+        : ''
+    );
 
     // 2. Set reasons
     setOtherDisabledReasons(Object.values(votingDisabledReasonsRef.current));
   }, [
     delegateAddress,
+    hasMembershipAtSnapshot,
     isAddressDelegated,
+    memberUnitsAtSnapshotStatus,
     setOtherDisabledReasons,
     voteChosen,
   ]);
@@ -152,6 +190,7 @@ export function OffchainVotingAction(
       if (!proposalHash) {
         throw new Error('No proposal hash was found.');
       }
+
       if (!snapshotProposalId) {
         throw new Error('No proposal ID was found.');
       }
@@ -166,10 +205,21 @@ export function OffchainVotingAction(
       });
 
       // Refetch to show the vote the user submitted
-      await proposal.refetchProposalOrDraft();
+      await refetchProposalOrDraft();
     } catch (error) {
       setSubmitError(error);
     }
+  }
+
+  function setDisabledReasonHelper(
+    key: keyof VotingDisabledReasons,
+    message: string
+  ): void {
+    votingDisabledReasonsRef.current = {
+      ...votingDisabledReasonsRef.current,
+
+      [key]: message,
+    };
   }
 
   return (
@@ -185,7 +235,7 @@ export function OffchainVotingAction(
       />
 
       <ErrorMessageWithDetails
-        error={submitError}
+        error={error}
         renderText="Something went wrong"
       />
 

--- a/src/components/proposals/voting/OffchainVotingAction.unit.test.tsx
+++ b/src/components/proposals/voting/OffchainVotingAction.unit.test.tsx
@@ -1,0 +1,696 @@
+import {
+  SnapshotProposalResponseData,
+  SnapshotType,
+} from '@openlaw/snapshot-js-erc712';
+import {render, screen, waitFor} from '@testing-library/react';
+import {Store} from 'redux';
+import userEvent from '@testing-library/user-event';
+import Web3 from 'web3';
+
+import {ContractAdapterNames} from '../../web3/types';
+import {DEFAULT_ETH_ADDRESS, FakeHttpProvider} from '../../../test/helpers';
+import {OffchainVotingAction} from './OffchainVotingAction';
+import {ProposalData, SnapshotProposal} from '../types';
+import {server, rest} from '../../../test/server';
+import {setConnectedMember} from '../../../store/actions';
+import {signTypedDataV4} from '../../../test/web3Responses';
+import {SNAPSHOT_HUB_API_URL} from '../../../config';
+import {snapshotAPIProposalResponse} from '../../../test/restResponses';
+import Wrapper from '../../../test/Wrapper';
+
+describe('OffchainVotingAction unit tests', () => {
+  const alreadyVotedRegex: RegExp = /you have already voted\./i;
+  const errorTextRegex: RegExp = /something went wrong/i;
+  const votedYesButtonRegex: RegExp = /voted yes/i;
+  const voteNoButtonRegex: RegExp = /vote no/i;
+  const voteYesButtonRegex: RegExp = /vote yes/i;
+  const votingWhyDisabledRegex: RegExp = /why is voting disabled\?/i;
+
+  const defaultProposalVotes: SnapshotProposalResponseData['votes'] = [
+    {
+      [DEFAULT_ETH_ADDRESS]: {
+        address: DEFAULT_ETH_ADDRESS,
+        msg: {
+          version: '0.2.0',
+          timestamp: '1614264732',
+          token: '0x8f56682a50becb1df2fb8136954f2062871bc7fc',
+          type: SnapshotType.vote,
+          payload: {
+            choice: 1, // Yes
+            proposalId:
+              '0x1679cac3f54777f5d9c95efd83beff9f87ac55487311ecacd95827d267a15c4e',
+            metadata: {
+              memberAddress: DEFAULT_ETH_ADDRESS,
+            },
+          },
+        },
+        sig: '0xdbdbf122734b34ed5b10542551636e4250e98f443e35bf5d625f284fe54dcaf80c5bc44be04fefed1e9e5f25a7c13809a5266fcdbdcd0b94c885f2128544e79a1b',
+        authorIpfsHash:
+          '0xfe8f864ef475f60c7e01d5425df332199c5ae7ab712b8545f07433c68f06c644',
+        relayerIpfsHash: '',
+        actionId: '0xFCB86F90bd7b30cDB8A2c43FB15bf5B33A70Ea4f',
+      },
+    },
+    {
+      '0xc0437e11094275376defbe51dc6e04598403d276': {
+        address: '0xc0437e11094275376defbe51dc6e04598403d276',
+        msg: {
+          version: '0.2.0',
+          timestamp: '1614264732',
+          token: '0x8f56682a50becb1df2fb8136954f2062871bc7fc',
+          type: SnapshotType.vote,
+          payload: {
+            choice: 2, // No
+            proposalId:
+              '0x1679cac3f54777f5d9c95efd83beff9f87ac55487311ecacd95827d267a15c4e',
+            metadata: {
+              memberAddress: '0xc0437e11094275376defbe51dc6e04598403d276',
+            },
+          },
+        },
+        sig: '0xdbdbf122734b34ed5b10542551636e4250e98f443e35bf5d625f284fe54dcaf80c5bc44be04fefed1e9e5f25a7c13809a5266fcdbdcd0b94c885f2128544e79a1b',
+        authorIpfsHash:
+          '0xfe8f864ef475f60c7e01d5425df332199c5ae7ab712b8545f07433c68f06c644',
+        relayerIpfsHash: '',
+        actionId: '0xFCB86F90bd7b30cDB8A2c43FB15bf5B33A70Ea4f',
+      },
+    },
+  ];
+
+  const defaultProposalBody = Object.values(snapshotAPIProposalResponse)[0];
+
+  // Use just enough proposal fixture data for what the test needs
+  const defaultProposalData = (
+    refetchSpy: jest.Mock
+  ): Partial<ProposalData> => ({
+    snapshotProposal: {
+      ...defaultProposalBody,
+      msg: {
+        ...defaultProposalBody.msg,
+        payload: {
+          ...defaultProposalBody.msg.payload,
+          name: 'Another cool one',
+        },
+      },
+      data: {
+        erc712DraftHash:
+          '0xb22ca9af120bfddfc2071b5e86a9edee6e0e2ab76399e7c2d96a9d502f5c3434',
+        authorIpfsHash: '',
+      },
+      votes: [],
+      idInDAO:
+        '0xb22ca9af120bfddfc2071b5e86a9edee6e0e2ab76399e7c2d96a9d502f5c3434',
+      idInSnapshot:
+        '0xb22ca9af120bfddfc2071b5e86a9edee6e0e2ab76399e7c2d96a9d502f5c3333',
+    } as SnapshotProposal,
+
+    refetchProposalOrDraft: refetchSpy,
+  });
+
+  test('should submit a vote', async () => {
+    const refetchSpy = jest.fn();
+    const proposal = defaultProposalData(refetchSpy) as ProposalData;
+
+    let mockWeb3Provider: FakeHttpProvider;
+    let web3Instance: Web3;
+
+    const {rerender} = render(
+      <Wrapper
+        useInit
+        useWallet
+        getProps={(p) => {
+          mockWeb3Provider = p.mockWeb3Provider;
+          web3Instance = p.web3Instance;
+        }}>
+        <OffchainVotingAction
+          adapterName={ContractAdapterNames.onboarding}
+          proposal={proposal}
+        />
+      </Wrapper>
+    );
+
+    await waitFor(() => {
+      // Mock RPC response for `useMemberUnitsAtSnapshot`
+      mockWeb3Provider.injectResult(
+        web3Instance.eth.abi.encodeParameter('uint256', 123456)
+      );
+    });
+
+    // Assert content
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', {name: voteYesButtonRegex})
+      ).toBeInTheDocument();
+
+      expect(
+        screen.getByRole('button', {name: voteNoButtonRegex})
+      ).toBeInTheDocument();
+
+      expect(
+        screen.getByRole('button', {name: voteYesButtonRegex})
+      ).toBeEnabled();
+
+      expect(
+        screen.getByRole('button', {name: voteNoButtonRegex})
+      ).toBeEnabled();
+
+      expect(() => screen.getByText(errorTextRegex)).toThrow();
+      expect(() => screen.getByText(votingWhyDisabledRegex)).toThrow();
+    });
+
+    await waitFor(() => {
+      // Mock signature response
+      mockWeb3Provider.injectResult(...signTypedDataV4({web3Instance}));
+    });
+
+    // Submit vote
+    userEvent.click(screen.getByRole('button', {name: voteYesButtonRegex}));
+
+    // Assert voting progress
+    await waitFor(() => {
+      expect(
+        screen.getByLabelText(/currently voting yes\.\.\./i)
+      ).toBeInTheDocument();
+    });
+
+    const proposalWithVotes = {
+      ...proposal,
+      snapshotProposal: {
+        ...proposal.snapshotProposal,
+        votes: defaultProposalVotes,
+      },
+    };
+
+    rerender(
+      <Wrapper useInit useWallet>
+        <OffchainVotingAction
+          adapterName={ContractAdapterNames.onboarding}
+          proposal={proposalWithVotes as ProposalData}
+        />
+      </Wrapper>
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', {name: votedYesButtonRegex})
+      ).toBeInTheDocument();
+
+      expect(
+        screen.getByRole('button', {name: voteNoButtonRegex})
+      ).toBeInTheDocument();
+
+      expect(
+        screen.getByRole('button', {name: votedYesButtonRegex})
+      ).toBeDisabled();
+
+      expect(
+        screen.getByRole('button', {name: voteNoButtonRegex})
+      ).toBeDisabled();
+
+      expect(screen.getByText(votingWhyDisabledRegex)).toBeInTheDocument();
+
+      expect(() => screen.getByText(errorTextRegex)).toThrow();
+    });
+
+    // Click the "why disabled?" link
+    userEvent.click(screen.getByText(votingWhyDisabledRegex));
+
+    // Assert "why voting disabled modal" content
+    await waitFor(() => {
+      expect(screen.getByText(alreadyVotedRegex)).toBeInTheDocument();
+    });
+
+    // Assert refetch was called
+    await waitFor(() => {
+      expect(refetchSpy.mock.calls.length === 1).toBe(true);
+    });
+  });
+
+  test('should disable submitting a vote for custom reasons', async () => {
+    const refetchSpy = jest.fn();
+    const proposal = defaultProposalData(refetchSpy) as ProposalData;
+
+    const proposalWithVotes = {
+      ...proposal,
+      snapshotProposal: {
+        ...proposal.snapshotProposal,
+        votes: defaultProposalVotes,
+      },
+    };
+
+    let mockWeb3Provider: FakeHttpProvider;
+    let web3Instance: Web3;
+    let store: Store;
+
+    const {rerender} = render(
+      <Wrapper
+        useInit
+        useWallet
+        getProps={(p) => {
+          mockWeb3Provider = p.mockWeb3Provider;
+          web3Instance = p.web3Instance;
+          store = p.store;
+        }}>
+        <OffchainVotingAction
+          adapterName={ContractAdapterNames.onboarding}
+          proposal={proposal}
+        />
+      </Wrapper>
+    );
+
+    // Mock RPC response for `useMemberUnitsAtSnapshot`
+    await waitFor(() => {
+      mockWeb3Provider.injectResult(
+        // Address had no weight at snapshot
+        web3Instance.eth.abi.encodeParameter('uint256', 0)
+      );
+    });
+
+    // Wait for connected member state to be set
+    await waitFor(() => {
+      expect(store.getState().connectedMember).not.toBe(null);
+    });
+
+    await waitFor(() => {
+      store.dispatch(
+        setConnectedMember({
+          ...store.getState().connectedMember,
+          delegateKey: '0xE11BA2b4D45Eaed5996Cd0823791E0C93114882d',
+          isAddressDelegated: true,
+        })
+      );
+    });
+
+    // Assert content
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', {name: voteYesButtonRegex})
+      ).toBeInTheDocument();
+
+      expect(
+        screen.getByRole('button', {name: voteNoButtonRegex})
+      ).toBeInTheDocument();
+
+      expect(
+        screen.getByRole('button', {name: voteYesButtonRegex})
+      ).toBeDisabled();
+
+      expect(
+        screen.getByRole('button', {name: voteNoButtonRegex})
+      ).toBeDisabled();
+
+      expect(screen.getByText(votingWhyDisabledRegex)).toBeInTheDocument();
+
+      expect(() => screen.getByText(errorTextRegex)).toThrow();
+    });
+
+    // Click the "why disabled?" link
+    userEvent.click(screen.getByText(votingWhyDisabledRegex));
+
+    // Assert `addressIsDelegatedMessage` message content
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          /your member address is delegated to 0xE11BA\.\.\.82d\. You must use that address to vote\./i
+        )
+      ).toBeInTheDocument();
+    });
+
+    // Revert the `connectedMember` state
+    await waitFor(() => {
+      store.dispatch(
+        setConnectedMember({
+          ...store.getState().connectedMember,
+          delegateKey: DEFAULT_ETH_ADDRESS,
+          isAddressDelegated: false,
+        })
+      );
+    });
+
+    // Assert `noMembershipAtSnapshotMessage` message content
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          /you were not a member when the proposal was sponsored\./i
+        )
+      ).toBeInTheDocument();
+    });
+
+    // Re-render with votes
+    rerender(
+      <Wrapper useInit useWallet>
+        <OffchainVotingAction
+          adapterName={ContractAdapterNames.onboarding}
+          proposal={proposalWithVotes as ProposalData}
+        />
+      </Wrapper>
+    );
+
+    // Assert `alreadyVotedMessage` message content
+    await waitFor(() => {
+      expect(screen.getByText(alreadyVotedRegex)).toBeInTheDocument();
+    });
+
+    const proposalToForceRerender = {
+      ...proposal,
+      snapshotProposal: {
+        ...proposal.snapshotProposal,
+        msg: {
+          ...proposal.snapshotProposal?.msg,
+          payload: {
+            ...proposal.snapshotProposal?.msg.payload,
+            // Update the snapshot to make `useMemberUnitsAtSnapshot` re-run
+            snapshot: 789,
+          },
+        },
+      },
+    };
+
+    /**
+     * We re-render as the timing is difficult to get right when
+     * trying to mock the `useMemberUnitsAtSnapshot` error.
+     */
+    rerender(
+      <Wrapper
+        useInit
+        useWallet
+        getProps={() => {
+          mockWeb3Provider.injectError({
+            code: 123,
+            message: 'Some bad error',
+          });
+        }}>
+        <OffchainVotingAction
+          adapterName={ContractAdapterNames.onboarding}
+          proposal={proposalToForceRerender as ProposalData}
+        />
+      </Wrapper>
+    );
+
+    // Assert `undeterminedMembershipAtSnapshotMessage` message content
+    await waitFor(() => {
+      expect(
+        screen.getByText(
+          /your membership status at the time this proposal was sponsored cannot be determined\./i
+        )
+      ).toBeInTheDocument();
+    });
+
+    // Assert refetch was called
+    await waitFor(() => {
+      expect(refetchSpy.mock.calls.length === 0).toBe(true);
+    });
+  });
+
+  test('should show an error when signing a vote fails', async () => {
+    const refetchSpy = jest.fn();
+    const proposal = defaultProposalData(refetchSpy) as ProposalData;
+
+    let mockWeb3Provider: FakeHttpProvider;
+    let web3Instance: Web3;
+
+    render(
+      <Wrapper
+        useInit
+        useWallet
+        getProps={(p) => {
+          mockWeb3Provider = p.mockWeb3Provider;
+          web3Instance = p.web3Instance;
+        }}>
+        <OffchainVotingAction
+          adapterName={ContractAdapterNames.onboarding}
+          proposal={proposal}
+        />
+      </Wrapper>
+    );
+
+    await waitFor(() => {
+      // Mock RPC response for `useMemberUnitsAtSnapshot`
+      mockWeb3Provider.injectResult(
+        web3Instance.eth.abi.encodeParameter('uint256', 123456)
+      );
+    });
+
+    // Assert content
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', {name: voteYesButtonRegex})
+      ).toBeInTheDocument();
+
+      expect(
+        screen.getByRole('button', {name: voteNoButtonRegex})
+      ).toBeInTheDocument();
+
+      expect(
+        screen.getByRole('button', {name: voteYesButtonRegex})
+      ).toBeEnabled();
+
+      expect(
+        screen.getByRole('button', {name: voteNoButtonRegex})
+      ).toBeEnabled();
+
+      expect(() => screen.getByText(errorTextRegex)).toThrow();
+      expect(() => screen.getByText(votingWhyDisabledRegex)).toThrow();
+    });
+
+    await waitFor(() => {
+      // Mock signature error response
+      mockWeb3Provider.injectError({code: 1234, message: 'Some bad error'});
+    });
+
+    // Submit vote
+    userEvent.click(screen.getByRole('button', {name: voteYesButtonRegex}));
+
+    // Assert voting progress
+    await waitFor(() => {
+      expect(
+        screen.getByLabelText(/currently voting yes\.\.\./i)
+      ).toBeInTheDocument();
+    });
+
+    // Assert error message
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', {name: voteYesButtonRegex})
+      ).toBeInTheDocument();
+
+      expect(
+        screen.getByRole('button', {name: voteNoButtonRegex})
+      ).toBeInTheDocument();
+
+      expect(
+        screen.getByRole('button', {name: voteYesButtonRegex})
+      ).toBeEnabled();
+
+      expect(
+        screen.getByRole('button', {name: voteNoButtonRegex})
+      ).toBeEnabled();
+
+      expect(screen.getByText(errorTextRegex)).toBeInTheDocument();
+      expect(screen.getByText(/some bad error/i)).toBeInTheDocument();
+
+      expect(() => screen.getByText(votingWhyDisabledRegex)).toThrow();
+    });
+
+    // Assert refetch was called
+    await waitFor(() => {
+      expect(refetchSpy.mock.calls.length === 0).toBe(true);
+    });
+  });
+
+  test('should show an error when submitting a vote fails', async () => {
+    // Mock a Snapshot `POST` error
+    server.use(
+      rest.post(`${SNAPSHOT_HUB_API_URL}/api/message`, async (_req, res, ctx) =>
+        res(ctx.status(500))
+      )
+    );
+
+    const refetchSpy = jest.fn();
+    const proposal = defaultProposalData(refetchSpy) as ProposalData;
+
+    let mockWeb3Provider: FakeHttpProvider;
+    let web3Instance: Web3;
+
+    render(
+      <Wrapper
+        useInit
+        useWallet
+        getProps={(p) => {
+          mockWeb3Provider = p.mockWeb3Provider;
+          web3Instance = p.web3Instance;
+        }}>
+        <OffchainVotingAction
+          adapterName={ContractAdapterNames.onboarding}
+          proposal={proposal}
+        />
+      </Wrapper>
+    );
+
+    await waitFor(() => {
+      // Mock RPC response for `useMemberUnitsAtSnapshot`
+      mockWeb3Provider.injectResult(
+        web3Instance.eth.abi.encodeParameter('uint256', 123456)
+      );
+    });
+
+    // Assert content
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', {name: voteYesButtonRegex})
+      ).toBeInTheDocument();
+
+      expect(
+        screen.getByRole('button', {name: voteNoButtonRegex})
+      ).toBeInTheDocument();
+
+      expect(
+        screen.getByRole('button', {name: voteYesButtonRegex})
+      ).toBeEnabled();
+
+      expect(
+        screen.getByRole('button', {name: voteNoButtonRegex})
+      ).toBeEnabled();
+
+      expect(() => screen.getByText(errorTextRegex)).toThrow();
+      expect(() => screen.getByText(votingWhyDisabledRegex)).toThrow();
+    });
+
+    await waitFor(() => {
+      // Mock signature response
+      mockWeb3Provider.injectResult(...signTypedDataV4({web3Instance}));
+    });
+
+    // Submit vote
+    userEvent.click(screen.getByRole('button', {name: voteYesButtonRegex}));
+
+    // Assert voting progress
+    await waitFor(() => {
+      expect(
+        screen.getByLabelText(/currently voting yes\.\.\./i)
+      ).toBeInTheDocument();
+    });
+
+    // Assert error message
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', {name: voteYesButtonRegex})
+      ).toBeInTheDocument();
+
+      expect(
+        screen.getByRole('button', {name: voteNoButtonRegex})
+      ).toBeInTheDocument();
+
+      expect(
+        screen.getByRole('button', {name: voteYesButtonRegex})
+      ).toBeEnabled();
+
+      expect(
+        screen.getByRole('button', {name: voteNoButtonRegex})
+      ).toBeEnabled();
+
+      expect(screen.getByText(errorTextRegex)).toBeInTheDocument();
+
+      expect(
+        screen.getByText(/request failed with status code 500/i)
+      ).toBeInTheDocument();
+
+      expect(() => screen.getByText(votingWhyDisabledRegex)).toThrow();
+    });
+
+    // Assert refetch was called
+    await waitFor(() => {
+      expect(refetchSpy.mock.calls.length === 0).toBe(true);
+    });
+  });
+
+  test('should show an error when `useMemberUnitsAtSnapshot` fails', async () => {
+    const refetchSpy = jest.fn();
+    const proposal = defaultProposalData(refetchSpy) as ProposalData;
+
+    let mockWeb3Provider: FakeHttpProvider;
+    let web3Instance: Web3;
+
+    const {rerender} = render(
+      <Wrapper
+        useInit
+        useWallet
+        getProps={(p) => {
+          mockWeb3Provider = p.mockWeb3Provider;
+          web3Instance = p.web3Instance;
+        }}>
+        <OffchainVotingAction
+          adapterName={ContractAdapterNames.onboarding}
+          proposal={proposal}
+        />
+      </Wrapper>
+    );
+
+    await waitFor(() => {
+      // Mock RPC response for `useMemberUnitsAtSnapshot`
+      mockWeb3Provider.injectResult(
+        web3Instance.eth.abi.encodeParameter('uint256', 123456)
+      );
+    });
+
+    const proposalToForceRerender = {
+      ...proposal,
+      snapshotProposal: {
+        ...proposal.snapshotProposal,
+        msg: {
+          ...proposal.snapshotProposal?.msg,
+          payload: {
+            ...proposal.snapshotProposal?.msg.payload,
+            // Update the snapshot to make `useMemberUnitsAtSnapshot` re-run
+            snapshot: 789,
+          },
+        },
+      },
+    };
+
+    /**
+     * We re-render as the timing is difficult to get right when
+     * trying to mock the `useMemberUnitsAtSnapshot` error.
+     */
+    rerender(
+      <Wrapper
+        useInit
+        useWallet
+        getProps={() => {
+          mockWeb3Provider.injectError({
+            code: 123,
+            message: 'Some bad error',
+          });
+        }}>
+        <OffchainVotingAction
+          adapterName={ContractAdapterNames.onboarding}
+          proposal={proposalToForceRerender as ProposalData}
+        />
+      </Wrapper>
+    );
+
+    // Assert error message
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', {name: voteYesButtonRegex})
+      ).toBeInTheDocument();
+
+      expect(
+        screen.getByRole('button', {name: voteNoButtonRegex})
+      ).toBeInTheDocument();
+
+      expect(
+        screen.getByRole('button', {name: voteYesButtonRegex})
+      ).toBeEnabled();
+
+      expect(
+        screen.getByRole('button', {name: voteNoButtonRegex})
+      ).toBeEnabled();
+
+      expect(screen.getByText(errorTextRegex)).toBeInTheDocument();
+      expect(screen.getByText(/some bad error/i)).toBeInTheDocument();
+
+      expect(() => screen.getByText(votingWhyDisabledRegex)).toThrow();
+    });
+  });
+});

--- a/src/components/proposals/voting/VotingActionButtons.tsx
+++ b/src/components/proposals/voting/VotingActionButtons.tsx
@@ -39,7 +39,7 @@ export function VotingActionButtons(
 
   function getButtonText(choice: VoteChoices): React.ReactNode {
     return voteProgress === choice ? (
-      <Loader aria-label={`Voting ${choice} spinner image`} role="img" />
+      <Loader aria-label={`Currently voting ${choice}...`} role="img" />
     ) : voteChosen === choice ? (
       `Voted ${choice}`
     ) : (

--- a/src/components/proposals/voting/VotingActionButtons.unit.test.tsx
+++ b/src/components/proposals/voting/VotingActionButtons.unit.test.tsx
@@ -61,8 +61,9 @@ describe('VotingActionButtons unit tests', () => {
     expect(screen.getByRole('button', {name: /voting no/i})).toBeDisabled();
     expect(screen.getByLabelText(/voting no \u2026/i)).toBeInTheDocument();
     expect(() => screen.getByText(/voting no \u2026/i)).toThrow();
+
     expect(
-      screen.getByLabelText(/voting no spinner image/i)
+      screen.getByLabelText(/currently voting no\.\.\./i)
     ).toBeInTheDocument();
   });
 
@@ -81,8 +82,9 @@ describe('VotingActionButtons unit tests', () => {
     expect(screen.getByRole('button', {name: /voting yes/i})).toBeDisabled();
     expect(screen.getByLabelText(/voting yes \u2026/i)).toBeInTheDocument();
     expect(() => screen.getByText(/voting yes \u2026/i)).toThrow();
+
     expect(
-      screen.getByLabelText(/voting yes spinner image/i)
+      screen.getByLabelText(/currently voting yes\.\.\./i)
     ).toBeInTheDocument();
   });
 });

--- a/src/components/proposals/voting/VotingStatus.tsx
+++ b/src/components/proposals/voting/VotingStatus.tsx
@@ -45,7 +45,7 @@ export function VotingStatus(props: VotingStatusProps) {
   return (
     <>
       <div className="votingstatus-container">
-        <StopwatchSVG aria-label="Counting down until voting ends" role="img" />
+        <StopwatchSVG aria-label="Proposal status" role="img" />
 
         {renderedStatus && (
           <span className="votingstatus">{renderedStatus}</span>

--- a/src/components/proposals/voting/VotingStatus.unit.test.tsx
+++ b/src/components/proposals/voting/VotingStatus.unit.test.tsx
@@ -29,9 +29,7 @@ describe('VotingStatus unit tests', () => {
     expect(screen.getByText(/5%/i)).toBeInTheDocument();
 
     // ClockSVG label
-    expect(
-      screen.getByLabelText(/counting down until voting ends/i)
-    ).toBeInTheDocument();
+    expect(screen.getByLabelText(/^proposal status$/i)).toBeInTheDocument();
 
     /**
      * Assert countdown

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -5,5 +5,6 @@ export * from './useDaoConfigurations';
 export * from './useDaoTotalUnits';
 export * from './useIsMounted';
 export * from './useMemberActionDisabled';
+export * from './useMemberUnitsAtSnapshot';
 export * from './useRedeemCoupon';
 export * from './useTimeStartEnd';

--- a/src/hooks/useMemberUnitsAtSnapshot.ts
+++ b/src/hooks/useMemberUnitsAtSnapshot.ts
@@ -1,0 +1,110 @@
+import {useSelector} from 'react-redux';
+import {useEffect, useState} from 'react';
+import BigNumber from 'bignumber.js';
+
+import {AsyncStatus} from '../util/types';
+import {StoreState} from '../store/types';
+import {UNITS_ADDRESS} from '../config';
+
+type UseMemberUnitsAtSnapshotReturn = {
+  /**
+   * Was the member to check a member of the DAO at the
+   * requested snapshot?
+   */
+  hasMembershipAtSnapshot: boolean;
+  /**
+   * Member units as a `string`.
+   * Convert to a `BigNumber`, if needed for calculation.
+   */
+  memberUnitsAtSnapshot: string | undefined;
+  memberUnitsAtSnapshotError: Error | undefined;
+  memberUnitsAtSnapshotStatus: AsyncStatus;
+};
+
+const {STANDBY, PENDING, FULFILLED, REJECTED} = AsyncStatus;
+
+export function useMemberUnitsAtSnapshot(
+  memberAddress: string,
+  snapshot: number
+): UseMemberUnitsAtSnapshotReturn {
+  /**
+   * Selectors
+   */
+
+  const bankExtensionMethods = useSelector(
+    (s: StoreState) => s.contracts.BankExtensionContract?.instance.methods
+  );
+
+  /**
+   * State
+   */
+
+  const [memberUnitsAtSnapshot, setMemberUnitsAtSnapshot] = useState<string>();
+
+  const [hasMembershipAtSnapshot, setHasMembershipAtSnapshot] =
+    useState<boolean>(false);
+
+  const [memberUnitsAtSnapshotError, setMemberUnitsAtSnapshotError] =
+    useState<Error>();
+
+  const [memberUnitsAtSnapshotStatus, setMemberUnitsAtSnapshotStatus] =
+    useState<AsyncStatus>(STANDBY);
+
+  /**
+   * Effects
+   */
+
+  useEffect(() => {
+    if (!bankExtensionMethods) return;
+
+    handleGetPriorUnitsAmount({
+      bankExtensionMethods,
+      memberAddress,
+      snapshot,
+    });
+  }, [bankExtensionMethods, memberAddress, snapshot]);
+
+  /**
+   * Functions
+   */
+
+  async function handleGetPriorUnitsAmount({
+    bankExtensionMethods,
+    memberAddress,
+    snapshot,
+  }: {
+    memberAddress: string;
+    snapshot: number;
+    bankExtensionMethods: any;
+  }): Promise<void> {
+    try {
+      // Reset any error
+      setMemberUnitsAtSnapshotError(undefined);
+      setMemberUnitsAtSnapshotStatus(PENDING);
+
+      const memberUnitsAtSnapshot: string = await bankExtensionMethods
+        .getPriorAmount(memberAddress, UNITS_ADDRESS, snapshot)
+        .call();
+
+      setMemberUnitsAtSnapshot(memberUnitsAtSnapshot);
+
+      setHasMembershipAtSnapshot(
+        new BigNumber(memberUnitsAtSnapshot).isGreaterThan(new BigNumber(0))
+      );
+
+      setMemberUnitsAtSnapshotStatus(FULFILLED);
+    } catch (error) {
+      setHasMembershipAtSnapshot(false);
+      setMemberUnitsAtSnapshot(undefined);
+      setMemberUnitsAtSnapshotError(error);
+      setMemberUnitsAtSnapshotStatus(REJECTED);
+    }
+  }
+
+  return {
+    hasMembershipAtSnapshot,
+    memberUnitsAtSnapshot,
+    memberUnitsAtSnapshotError,
+    memberUnitsAtSnapshotStatus,
+  };
+}

--- a/src/hooks/useMemberUnitsAtSnapshot.ts
+++ b/src/hooks/useMemberUnitsAtSnapshot.ts
@@ -24,8 +24,8 @@ type UseMemberUnitsAtSnapshotReturn = {
 const {STANDBY, PENDING, FULFILLED, REJECTED} = AsyncStatus;
 
 export function useMemberUnitsAtSnapshot(
-  memberAddress: string,
-  snapshot: number
+  memberAddress: string | undefined,
+  snapshot: number | undefined
 ): UseMemberUnitsAtSnapshotReturn {
   /**
    * Selectors
@@ -55,7 +55,8 @@ export function useMemberUnitsAtSnapshot(
    */
 
   useEffect(() => {
-    if (!bankExtensionMethods) return;
+    // These parameters may be arriving async and not ready, yet.
+    if (!memberAddress || !snapshot || !bankExtensionMethods) return;
 
     handleGetPriorUnitsAmount({
       bankExtensionMethods,

--- a/src/hooks/useMemberUnitsAtSnapshot.ts
+++ b/src/hooks/useMemberUnitsAtSnapshot.ts
@@ -1,10 +1,13 @@
+import {useCallback, useEffect, useState} from 'react';
 import {useSelector} from 'react-redux';
-import {useEffect, useState} from 'react';
 import BigNumber from 'bignumber.js';
+import Web3 from 'web3';
 
 import {AsyncStatus} from '../util/types';
+import {ENVIRONMENT, UNITS_ADDRESS} from '../config';
 import {StoreState} from '../store/types';
-import {UNITS_ADDRESS} from '../config';
+import {useIsMounted} from './useIsMounted';
+import {useWeb3Modal} from '../components/web3/hooks';
 
 type UseMemberUnitsAtSnapshotReturn = {
   /**
@@ -23,10 +26,96 @@ type UseMemberUnitsAtSnapshotReturn = {
 
 const {STANDBY, PENDING, FULFILLED, REJECTED} = AsyncStatus;
 
+const DEFAULT_POLL_INTERVAL_MS: number =
+  ENVIRONMENT === 'production' ? 15000 : 5000;
+
+const DEFAULT_BLOCK_CHECK_OFFSET: number = 2;
+
+/**
+ * In order for `getPriorAmount` to return without reverting,
+ * we must be sending a block number from the past.
+ *
+ * We must poll to wait until the block is in the past.
+ * We could poll `getPriorAmount` until it does not revert, but
+ * doing this could hide other errors.
+ *
+ * @param number `blockToCompare`
+ * @param Web3 `web3Instance`
+ * @returns `boolean`
+ * @see `getPriorAmount` in `tribute-contracts`
+ */
+async function pollUntilBlockInPast({
+  block,
+  blockOffset = DEFAULT_BLOCK_CHECK_OFFSET,
+  isMountedRef,
+  pollInterval = DEFAULT_POLL_INTERVAL_MS,
+  web3Instance,
+}: {
+  block: number;
+  blockOffset?: number;
+  isMountedRef?: React.MutableRefObject<boolean>;
+  pollInterval?: number;
+  web3Instance: Web3;
+}) {
+  return new Promise<boolean>(async (resolve, reject) => {
+    /**
+     * Uses a positive block offset to check if the difference between `block` provided
+     * and `currentBlock` is at least at or greater than the `blockOffset`.
+     *
+     * This is used to limit errors from `getPriorAmount` when the block is not in the past.
+     * If we set an offset, it helps to mitigate issues where the fetched block number
+     * and the `block.number in the contract are not yet aligned.
+     */
+    const blockOffsetCheck = (block: number, currentBlock: number): boolean => {
+      const blockDifference: number = currentBlock - block;
+
+      return blockDifference >= Math.abs(blockOffset);
+    };
+
+    // Check immediately
+    try {
+      if (blockOffsetCheck(block, await web3Instance.eth.getBlockNumber())) {
+        resolve(true);
+
+        return;
+      }
+    } catch (error) {
+      reject(error);
+
+      return;
+    }
+
+    // If the initial check did not succeed, begin to poll.
+    const intervalId = setInterval(async () => {
+      try {
+        if (!isMountedRef?.current) {
+          clearInterval(intervalId);
+
+          return;
+        }
+
+        if (blockOffsetCheck(block, await web3Instance.eth.getBlockNumber())) {
+          clearInterval(intervalId);
+          resolve(true);
+        }
+      } catch (error) {
+        clearInterval(intervalId);
+        reject(error);
+      }
+    }, pollInterval);
+  });
+}
+
 export function useMemberUnitsAtSnapshot(
   memberAddress: string | undefined,
-  snapshot: number | undefined
+  snapshot: number | undefined,
+  options?: {
+    blockCheckOffset?: number;
+    currentBlockPollIntervalMs?: number;
+  }
 ): UseMemberUnitsAtSnapshotReturn {
+  const {blockCheckOffset, currentBlockPollIntervalMs} = options || {};
+
   /**
    * Selectors
    */
@@ -51,19 +140,48 @@ export function useMemberUnitsAtSnapshot(
     useState<AsyncStatus>(STANDBY);
 
   /**
+   * Our hooks
+   */
+
+  const {web3Instance} = useWeb3Modal();
+  const {isMountedRef} = useIsMounted();
+
+  /**
+   * Cached Callbacks
+   */
+
+  const handleGetPriorUnitsAmountCached = useCallback(
+    handleGetPriorUnitsAmount,
+    [isMountedRef]
+  );
+
+  /**
    * Effects
    */
 
   useEffect(() => {
     // These parameters may be arriving async and not ready, yet.
-    if (!memberAddress || !snapshot || !bankExtensionMethods) return;
+    if (!memberAddress || !snapshot || !bankExtensionMethods || !web3Instance) {
+      return;
+    }
 
-    handleGetPriorUnitsAmount({
+    handleGetPriorUnitsAmountCached({
       bankExtensionMethods,
+      blockCheckOffset,
+      currentBlockPollIntervalMs,
       memberAddress,
       snapshot,
+      web3Instance,
     });
-  }, [bankExtensionMethods, memberAddress, snapshot]);
+  }, [
+    bankExtensionMethods,
+    blockCheckOffset,
+    currentBlockPollIntervalMs,
+    handleGetPriorUnitsAmountCached,
+    memberAddress,
+    snapshot,
+    web3Instance,
+  ]);
 
   /**
    * Functions
@@ -71,21 +189,46 @@ export function useMemberUnitsAtSnapshot(
 
   async function handleGetPriorUnitsAmount({
     bankExtensionMethods,
+    blockCheckOffset,
+    currentBlockPollIntervalMs,
     memberAddress,
     snapshot,
+    web3Instance,
   }: {
+    bankExtensionMethods: any;
+    blockCheckOffset?: number;
+    currentBlockPollIntervalMs?: number;
     memberAddress: string;
     snapshot: number;
-    bankExtensionMethods: any;
+    web3Instance: Web3;
   }): Promise<void> {
     try {
       // Reset any error
       setMemberUnitsAtSnapshotError(undefined);
       setMemberUnitsAtSnapshotStatus(PENDING);
 
+      /**
+       * Poll until we are at a block in the past.
+       *
+       * For example, in governance votes, this can be an issue for anyone trying
+       * to vote in the same block as the proposal's snapshot,
+       * as `getPriorAmount` will revert if `blockToCheck >= block.number`.
+       *
+       * This is not an issue with on-chain proposals.
+       */
+      await pollUntilBlockInPast({
+        block: snapshot,
+        blockOffset: blockCheckOffset,
+        isMountedRef,
+        pollInterval: currentBlockPollIntervalMs,
+        web3Instance,
+      });
+
       const memberUnitsAtSnapshot: string = await bankExtensionMethods
         .getPriorAmount(memberAddress, UNITS_ADDRESS, snapshot)
         .call();
+
+      if (!isMountedRef.current) return;
 
       setMemberUnitsAtSnapshot(memberUnitsAtSnapshot);
 
@@ -95,6 +238,8 @@ export function useMemberUnitsAtSnapshot(
 
       setMemberUnitsAtSnapshotStatus(FULFILLED);
     } catch (error) {
+      if (!isMountedRef.current) return;
+
       setHasMembershipAtSnapshot(false);
       setMemberUnitsAtSnapshot(undefined);
       setMemberUnitsAtSnapshotError(error);

--- a/src/hooks/useMemberUnitsAtSnapshot.unit.test.ts
+++ b/src/hooks/useMemberUnitsAtSnapshot.unit.test.ts
@@ -1,0 +1,179 @@
+import {act, renderHook} from '@testing-library/react-hooks';
+import Web3 from 'web3';
+
+import {AsyncStatus} from '../util/types';
+import {DEFAULT_ETH_ADDRESS, FakeHttpProvider} from '../test/helpers';
+import {useMemberUnitsAtSnapshot} from './useMemberUnitsAtSnapshot';
+import Wrapper from '../test/Wrapper';
+
+describe('useMemberUnitsAtSnapshot unit tests', () => {
+  const {STANDBY, PENDING, FULFILLED, REJECTED} = AsyncStatus;
+
+  test('should return correct data when member has units at snapshot', async () => {
+    let mockWebProvider: FakeHttpProvider;
+    let web3Instance: Web3;
+
+    await act(async () => {
+      const {result, waitForValueToChange, waitForNextUpdate} =
+        await renderHook(
+          () => useMemberUnitsAtSnapshot(DEFAULT_ETH_ADDRESS, 123),
+          {
+            wrapper: Wrapper,
+            initialProps: {
+              useInit: true,
+              useWallet: true,
+              getProps: (p) => {
+                mockWebProvider = p.mockWeb3Provider;
+                web3Instance = p.web3Instance;
+              },
+            },
+          }
+        );
+
+      // Assert initial state
+      expect(result.current.hasMembershipAtSnapshot).toBe(false);
+      expect(result.current.memberUnitsAtSnapshot).toBe(undefined);
+      expect(result.current.memberUnitsAtSnapshotError).toBe(undefined);
+      expect(result.current.memberUnitsAtSnapshotStatus).toBe(STANDBY);
+
+      await waitForNextUpdate();
+
+      // Mock `getPriorAmount` response
+      mockWebProvider.injectResult(
+        web3Instance.eth.abi.encodeParameter('uint256', 123456)
+      );
+
+      await waitForValueToChange(
+        () => result.current.memberUnitsAtSnapshotStatus
+      );
+
+      // Assert pending state
+      expect(result.current.hasMembershipAtSnapshot).toBe(false);
+      expect(result.current.memberUnitsAtSnapshot).toBe(undefined);
+      expect(result.current.memberUnitsAtSnapshotError).toBe(undefined);
+      expect(result.current.memberUnitsAtSnapshotStatus).toBe(PENDING);
+
+      await waitForValueToChange(
+        () => result.current.memberUnitsAtSnapshotStatus
+      );
+
+      // Assert fulfilled state
+      expect(result.current.hasMembershipAtSnapshot).toBe(true);
+      expect(result.current.memberUnitsAtSnapshot).toBe('123456');
+      expect(result.current.memberUnitsAtSnapshotError).toBe(undefined);
+      expect(result.current.memberUnitsAtSnapshotStatus).toBe(FULFILLED);
+    });
+  });
+
+  test('should return correct data when member has no units at snapshot', async () => {
+    let mockWebProvider: FakeHttpProvider;
+    let web3Instance: Web3;
+
+    await act(async () => {
+      const {result, waitForValueToChange, waitForNextUpdate} =
+        await renderHook(
+          () => useMemberUnitsAtSnapshot(DEFAULT_ETH_ADDRESS, 123),
+          {
+            wrapper: Wrapper,
+            initialProps: {
+              useInit: true,
+              useWallet: true,
+              getProps: (p) => {
+                mockWebProvider = p.mockWeb3Provider;
+                web3Instance = p.web3Instance;
+              },
+            },
+          }
+        );
+
+      // Assert initial state
+      expect(result.current.hasMembershipAtSnapshot).toBe(false);
+      expect(result.current.memberUnitsAtSnapshot).toBe(undefined);
+      expect(result.current.memberUnitsAtSnapshotError).toBe(undefined);
+      expect(result.current.memberUnitsAtSnapshotStatus).toBe(STANDBY);
+
+      await waitForNextUpdate();
+
+      // Mock `getPriorAmount` response
+      mockWebProvider.injectResult(
+        web3Instance.eth.abi.encodeParameter('uint256', 0)
+      );
+
+      await waitForValueToChange(
+        () => result.current.memberUnitsAtSnapshotStatus
+      );
+
+      // Assert pending state
+      expect(result.current.hasMembershipAtSnapshot).toBe(false);
+      expect(result.current.memberUnitsAtSnapshot).toBe(undefined);
+      expect(result.current.memberUnitsAtSnapshotError).toBe(undefined);
+      expect(result.current.memberUnitsAtSnapshotStatus).toBe(PENDING);
+
+      await waitForValueToChange(
+        () => result.current.memberUnitsAtSnapshotStatus
+      );
+
+      // Assert fulfilled state
+      expect(result.current.hasMembershipAtSnapshot).toBe(false);
+      expect(result.current.memberUnitsAtSnapshot).toBe('0');
+      expect(result.current.memberUnitsAtSnapshotError).toBe(undefined);
+      expect(result.current.memberUnitsAtSnapshotStatus).toBe(FULFILLED);
+    });
+  });
+
+  test('should return correct data when web3 error', async () => {
+    let mockWebProvider: FakeHttpProvider;
+
+    await act(async () => {
+      const {result, waitForValueToChange, waitForNextUpdate} =
+        await renderHook(
+          () => useMemberUnitsAtSnapshot(DEFAULT_ETH_ADDRESS, 123),
+          {
+            wrapper: Wrapper,
+            initialProps: {
+              useInit: true,
+              useWallet: true,
+              getProps: (p) => {
+                mockWebProvider = p.mockWeb3Provider;
+              },
+            },
+          }
+        );
+
+      // Assert initial state
+      expect(result.current.hasMembershipAtSnapshot).toBe(false);
+      expect(result.current.memberUnitsAtSnapshot).toBe(undefined);
+      expect(result.current.memberUnitsAtSnapshotError).toBe(undefined);
+      expect(result.current.memberUnitsAtSnapshotStatus).toBe(STANDBY);
+
+      await waitForNextUpdate();
+
+      // Mock web3 error response
+      mockWebProvider.injectError({code: 1234, message: 'Some bad error'});
+
+      await waitForValueToChange(
+        () => result.current.memberUnitsAtSnapshotStatus
+      );
+
+      // Assert pending state
+      expect(result.current.hasMembershipAtSnapshot).toBe(false);
+      expect(result.current.memberUnitsAtSnapshot).toBe(undefined);
+      expect(result.current.memberUnitsAtSnapshotError).toBe(undefined);
+      expect(result.current.memberUnitsAtSnapshotStatus).toBe(PENDING);
+
+      await waitForValueToChange(
+        () => result.current.memberUnitsAtSnapshotStatus
+      );
+
+      // Assert fulfilled state
+      expect(result.current.hasMembershipAtSnapshot).toBe(false);
+      expect(result.current.memberUnitsAtSnapshot).toBe(undefined);
+
+      expect(result.current.memberUnitsAtSnapshotError?.message).toMatch(
+        /some bad error/i
+      );
+
+      expect(result.current.memberUnitsAtSnapshotStatus).toBe(REJECTED);
+    });
+  });
+});

--- a/src/hooks/useMemberUnitsAtSnapshot.unit.test.ts
+++ b/src/hooks/useMemberUnitsAtSnapshot.unit.test.ts
@@ -10,7 +10,7 @@ describe('useMemberUnitsAtSnapshot unit tests', () => {
   const {STANDBY, PENDING, FULFILLED, REJECTED} = AsyncStatus;
 
   test('should return correct data when member has units at snapshot', async () => {
-    let mockWebProvider: FakeHttpProvider;
+    let mockWeb3Provider: FakeHttpProvider;
     let web3Instance: Web3;
 
     await act(async () => {
@@ -23,7 +23,7 @@ describe('useMemberUnitsAtSnapshot unit tests', () => {
               useInit: true,
               useWallet: true,
               getProps: (p) => {
-                mockWebProvider = p.mockWeb3Provider;
+                mockWeb3Provider = p.mockWeb3Provider;
                 web3Instance = p.web3Instance;
               },
             },
@@ -39,7 +39,7 @@ describe('useMemberUnitsAtSnapshot unit tests', () => {
       await waitForNextUpdate();
 
       // Mock `getPriorAmount` response
-      mockWebProvider.injectResult(
+      mockWeb3Provider.injectResult(
         web3Instance.eth.abi.encodeParameter('uint256', 123456)
       );
 
@@ -66,7 +66,7 @@ describe('useMemberUnitsAtSnapshot unit tests', () => {
   });
 
   test('should return correct data when member has no units at snapshot', async () => {
-    let mockWebProvider: FakeHttpProvider;
+    let mockWeb3Provider: FakeHttpProvider;
     let web3Instance: Web3;
 
     await act(async () => {
@@ -79,7 +79,7 @@ describe('useMemberUnitsAtSnapshot unit tests', () => {
               useInit: true,
               useWallet: true,
               getProps: (p) => {
-                mockWebProvider = p.mockWeb3Provider;
+                mockWeb3Provider = p.mockWeb3Provider;
                 web3Instance = p.web3Instance;
               },
             },
@@ -95,7 +95,7 @@ describe('useMemberUnitsAtSnapshot unit tests', () => {
       await waitForNextUpdate();
 
       // Mock `getPriorAmount` response
-      mockWebProvider.injectResult(
+      mockWeb3Provider.injectResult(
         web3Instance.eth.abi.encodeParameter('uint256', 0)
       );
 
@@ -121,8 +121,37 @@ describe('useMemberUnitsAtSnapshot unit tests', () => {
     });
   });
 
+  test('should return correct data when arguments `undefined`', async () => {
+    await act(async () => {
+      const {result, waitForNextUpdate} = await renderHook(
+        () => useMemberUnitsAtSnapshot(undefined, undefined),
+        {
+          wrapper: Wrapper,
+          initialProps: {
+            useInit: true,
+            useWallet: true,
+          },
+        }
+      );
+
+      // Assert initial state
+      expect(result.current.hasMembershipAtSnapshot).toBe(false);
+      expect(result.current.memberUnitsAtSnapshot).toBe(undefined);
+      expect(result.current.memberUnitsAtSnapshotError).toBe(undefined);
+      expect(result.current.memberUnitsAtSnapshotStatus).toBe(STANDBY);
+
+      await waitForNextUpdate();
+
+      // Assert pending state
+      expect(result.current.hasMembershipAtSnapshot).toBe(false);
+      expect(result.current.memberUnitsAtSnapshot).toBe(undefined);
+      expect(result.current.memberUnitsAtSnapshotError).toBe(undefined);
+      expect(result.current.memberUnitsAtSnapshotStatus).toBe(STANDBY);
+    });
+  });
+
   test('should return correct data when web3 error', async () => {
-    let mockWebProvider: FakeHttpProvider;
+    let mockWeb3Provider: FakeHttpProvider;
 
     await act(async () => {
       const {result, waitForValueToChange, waitForNextUpdate} =
@@ -134,7 +163,7 @@ describe('useMemberUnitsAtSnapshot unit tests', () => {
               useInit: true,
               useWallet: true,
               getProps: (p) => {
-                mockWebProvider = p.mockWeb3Provider;
+                mockWeb3Provider = p.mockWeb3Provider;
               },
             },
           }
@@ -149,7 +178,7 @@ describe('useMemberUnitsAtSnapshot unit tests', () => {
       await waitForNextUpdate();
 
       // Mock web3 error response
-      mockWebProvider.injectError({code: 1234, message: 'Some bad error'});
+      mockWeb3Provider.injectError({code: 1234, message: 'Some bad error'});
 
       await waitForValueToChange(
         () => result.current.memberUnitsAtSnapshotStatus

--- a/src/pages/governance/GovernanceProposalDetails.unit.test.tsx
+++ b/src/pages/governance/GovernanceProposalDetails.unit.test.tsx
@@ -80,18 +80,16 @@ describe('GovernanceProposalDetails unit tests', () => {
      */
 
     await waitFor(() => {
-      expect(
-        screen.getByLabelText(/counting down until voting ends/i)
-      ).toBeInTheDocument();
+      // SVG
+      expect(screen.getByLabelText(/^proposal status$/i)).toBeInTheDocument();
       expect(screen.getAllByText(/0%/i).length).toBe(2);
       expect(screen.getByLabelText(/0% yes votes/i)).toBeInTheDocument();
       expect(screen.getByLabelText(/0% no votes/i)).toBeInTheDocument();
     });
 
     await waitFor(() => {
-      expect(
-        screen.getByLabelText(/counting down until voting ends/i)
-      ).toBeInTheDocument();
+      // SVG
+      expect(screen.getByLabelText(/^proposal status$/i)).toBeInTheDocument();
       expect(screen.getAllByText(/0%/i).length).toBe(2);
       expect(screen.getByLabelText(/0% yes votes/i)).toBeInTheDocument();
       expect(screen.getByLabelText(/0% no votes/i)).toBeInTheDocument();

--- a/src/pages/governance/GovernanceProposals.unit.test.tsx
+++ b/src/pages/governance/GovernanceProposals.unit.test.tsx
@@ -10,13 +10,12 @@ import {rest, server} from '../../test/server';
 import {SNAPSHOT_HUB_API_URL} from '../../config';
 import {snapshotAPIProposalResponse} from '../../test/restResponses';
 import GovernanceProposals from './GovernanceProposals';
-import MulticallABI from '../../truffle-contracts/Multicall.json';
 import Wrapper from '../../test/Wrapper';
 
 describe('GovernanceProposals unit tests', () => {
   const defaultProposalVotes: SnapshotProposalResponseData['votes'] = [
     {
-      DEFAULT_ETH_ADDRESS: {
+      [DEFAULT_ETH_ADDRESS]: {
         address: DEFAULT_ETH_ADDRESS,
         msg: {
           version: '0.2.0',

--- a/src/test/helpers/FakeHttpProvider.ts
+++ b/src/test/helpers/FakeHttpProvider.ts
@@ -90,12 +90,12 @@ export class FakeHttpProvider {
     params?: any[] | Record<string, any>;
   }): Promise<any> {
     try {
-      const {result, debugName} = (this.getResponseOrError(
+      const {result, debugName: debugNameResponse} = (this.getResponseOrError(
         'response',
         payload
       ) || {}) as ResponseStub;
 
-      const {error} =
+      const {error, debugName: debugNameError} =
         (this.getResponseOrError('error', payload) as ErrorStub) || {};
 
       if (this.isDebugActive) {
@@ -106,9 +106,9 @@ export class FakeHttpProvider {
             '\nMETHOD: ' +
             payload.method +
             '\nDEBUG METHOD NAME: ' +
-            debugName +
-            '\nENCODED RESULT: ' +
-            result
+            (error ? debugNameError : debugNameResponse) +
+            '\nENCODED RESULT OR ERROR: ' +
+            (error ? JSON.stringify(error) : result)
         );
       }
 


### PR DESCRIPTION
Fixes #445 

🥳 **Adds**

 - `useMemberUnitsAtSnapshot` hook
 - `OffchainVotingAction` unit tests

✨ **Updates**

 - Adds `useMemberUnitsAtSnapshot` to `OffchainVotingAction` to check if member held units by _x_ snapshot
 - Changes `aria-label` for voting buttons when submitting vote
 - Improvements to the async processes of `useTimeStartEnd`
 
🐞 **Bugs squashed**

 - Fixes for debug for `FakeHttpProvider`
 - Fixes default proposal votes in some unit tests
 - `GovernanceActions` no longer briefly renders `OffchainVotingAction` when should not