### PR TITLE
Checks `getBadNodeError` before submitting off-chain vote result

### DIFF
--- a/src/components/proposals/voting/types.ts
+++ b/src/components/proposals/voting/types.ts
@@ -13,6 +13,18 @@ export enum VotingState {
 }
 
 /**
+ * @see `OffchainVoting.sol->getBadNodeError` in tribute-contracts
+ */
+export enum BadNodeError {
+  OK,
+  WRONG_PROPOSAL_ID,
+  INVALID_CHOICE,
+  AFTER_VOTING_PERIOD,
+  BAD_SIGNATURE,
+  INDEX_OUT_OF_BOUND,
+}
+
+/**
  * Response when calling `GET snapshot-hub/api/:space/offchain_proof/:merkle_root`
  */
 export type SnapshotOffchainProofResponse = {


### PR DESCRIPTION
Fixes #447

🥳 **Adds**

 - `enum BadNodeError` to match smart contract

✨ **Updates**

 - `OffchainOpRollupVotingSubmitResultAction` now checks `getBadNodeError` before submitting the vote result
 - `OffchainOpRollupVotingSubmitResultAction` unit tests
 
🐞 **Bugs squashed**

 - Fixes bug where a user could submit a bad off-chain proof (at least according to `getBadNodeError`) to Snapshot Hub.

