### PR TITLE
Generates contract types before build script runs

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "typescript": "^4.3.2"
   },
   "scripts": {
-    "build": "react-scripts build",
+    "build": "npm run generate-abi-types && react-scripts build",
     "eject": "react-scripts eject",
     "generate-abi-types": "typechain --target=web3-v1 --out-dir='abi-types' 'src/abis/*.json'",
     "postinstall": "npm run generate-abi-types",


### PR DESCRIPTION
Relates to #439 
 
🐞 **Bugs squashed**

 - Should fix GH Pages deployment error where types could not be found

