### PR TITLE
Proposal data caching

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "react-lines-ellipsis": "^0.15.0",
         "react-media": "^1.10.0",
         "react-modal": "^3.13.1",
+        "react-query": "^3.19.1",
         "react-redux": "^7.2.4",
         "react-router-dom": "^5.2.0",
         "react-scripts": "4.0.3",
@@ -5814,6 +5815,14 @@
         "node": ">= 8.0.0"
       }
     },
+    "node_modules/big-integer": {
+      "version": "1.6.48",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.48.tgz",
+      "integrity": "sha512-j51egjPa7/i+RdiRuJbPdJ2FIUYYPhvYLjzoYbcMMm62ooO6F94fETG4MTs46zPAF9Brs04OajboA/qTGuz78w==",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
     "node_modules/big.js": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
@@ -6011,6 +6020,21 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/broadcast-channel": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/broadcast-channel/-/broadcast-channel-3.7.0.tgz",
+      "integrity": "sha512-cIAKJXAxGJceNZGTZSBzMxzyOn72cVgPnKx4dc6LRjQgbaJUQqhy5rzL3zbMxkMWsGKkv2hSFkPRMEXfoMZ2Mg==",
+      "dependencies": {
+        "@babel/runtime": "^7.7.2",
+        "detect-node": "^2.1.0",
+        "js-sha3": "0.8.0",
+        "microseconds": "0.2.0",
+        "nano-time": "1.0.0",
+        "oblivious-set": "1.0.0",
+        "rimraf": "3.0.2",
+        "unload": "2.2.0"
       }
     },
     "node_modules/brorand": {
@@ -15221,6 +15245,15 @@
         "react": ">= 0.14.0"
       }
     },
+    "node_modules/match-sorter": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/match-sorter/-/match-sorter-6.3.0.tgz",
+      "integrity": "sha512-efYOf/wUpNb8FgNY+cOD2EIJI1S5I7YPKsw0LBp7wqPh5pmMS6i/wr3ZWwfwrAw1NvqTA2KUReVRWDX84lUcOQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "remove-accents": "0.4.2"
+      }
+    },
     "node_modules/md5.js": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
@@ -15481,6 +15514,11 @@
       "engines": {
         "node": ">=8.6"
       }
+    },
+    "node_modules/microseconds": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/microseconds/-/microseconds-0.2.0.tgz",
+      "integrity": "sha512-n7DHHMjR1avBbSpsTBj6fmMGh2AGrifVV4e+WYc3Q9lO+xnSZ3NyhcBND3vzzatt05LFhoKFRxrIyklmLlUtyA=="
     },
     "node_modules/miller-rabin": {
       "version": "4.0.1",
@@ -16010,6 +16048,14 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/nano-json-stream-parser/-/nano-json-stream-parser-0.1.2.tgz",
       "integrity": "sha1-DMj20OK2IrR5xA1JnEbWS3Vcb18="
+    },
+    "node_modules/nano-time": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/nano-time/-/nano-time-1.0.0.tgz",
+      "integrity": "sha1-sFVPaa2J4i0JB/ehKwmTpdlhN+8=",
+      "dependencies": {
+        "big-integer": "^1.6.16"
+      }
     },
     "node_modules/nanoid": {
       "version": "3.1.23",
@@ -16878,6 +16924,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/oblivious-set": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/oblivious-set/-/oblivious-set-1.0.0.tgz",
+      "integrity": "sha512-z+pI07qxo4c2CulUHCDf9lcqDlMSo72N/4rLUpRXf6fu+q8vjt8y0xS+Tlf8NTJDdTXHbdeO1n3MlbctwEoXZw=="
     },
     "node_modules/oboe": {
       "version": "2.1.5",
@@ -19924,6 +19975,31 @@
         "react-dom": "^0.14.0 || ^15.0.0 || ^16 || ^17"
       }
     },
+    "node_modules/react-query": {
+      "version": "3.19.1",
+      "resolved": "https://registry.npmjs.org/react-query/-/react-query-3.19.1.tgz",
+      "integrity": "sha512-tMBVKlmWevPHYWgI8ZBEgsTulJXSuXsxDbxqANODRnPI+3hd5GRVcc7nNIYSUx3aaULt08rN3EhTMHyTcFUNJw==",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "broadcast-channel": "^3.4.1",
+        "match-sorter": "^6.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-redux": {
       "version": "7.2.4",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.4.tgz",
@@ -21781,6 +21857,11 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/remove-accents": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.4.2.tgz",
+      "integrity": "sha1-CkPTqq4egNuRngeuJUsoXZ4ce7U="
     },
     "node_modules/remove-trailing-separator": {
       "version": "1.1.0",
@@ -25581,6 +25662,15 @@
       "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/unload": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/unload/-/unload-2.2.0.tgz",
+      "integrity": "sha512-B60uB5TNBLtN6/LsgAf3udH9saB5p7gqJwcFfbOEZ8BcBHnGwCf6G/TGiEqkRAxX7zAFIUtzdrXQSdL3Q/wqNA==",
+      "dependencies": {
+        "@babel/runtime": "^7.6.2",
+        "detect-node": "^2.0.4"
       }
     },
     "node_modules/unpipe": {
@@ -33151,6 +33241,11 @@
         "tryer": "^1.0.1"
       }
     },
+    "big-integer": {
+      "version": "1.6.48",
+      "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.48.tgz",
+      "integrity": "sha512-j51egjPa7/i+RdiRuJbPdJ2FIUYYPhvYLjzoYbcMMm62ooO6F94fETG4MTs46zPAF9Brs04OajboA/qTGuz78w=="
+    },
     "big.js": {
       "version": "5.2.2",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
@@ -33315,6 +33410,21 @@
       "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
       "requires": {
         "fill-range": "^7.0.1"
+      }
+    },
+    "broadcast-channel": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/broadcast-channel/-/broadcast-channel-3.7.0.tgz",
+      "integrity": "sha512-cIAKJXAxGJceNZGTZSBzMxzyOn72cVgPnKx4dc6LRjQgbaJUQqhy5rzL3zbMxkMWsGKkv2hSFkPRMEXfoMZ2Mg==",
+      "requires": {
+        "@babel/runtime": "^7.7.2",
+        "detect-node": "^2.1.0",
+        "js-sha3": "0.8.0",
+        "microseconds": "0.2.0",
+        "nano-time": "1.0.0",
+        "oblivious-set": "1.0.0",
+        "rimraf": "3.0.2",
+        "unload": "2.2.0"
       }
     },
     "brorand": {
@@ -40621,6 +40731,15 @@
       "integrity": "sha512-jtQ6VyT7rMT5tPV0g2EJakEnXLiPksnvlYtwQsVVZ611JsWGN8bQ1tVSDX4s6JllfEH6wmsYxNjTUAMrPmNA8w==",
       "requires": {}
     },
+    "match-sorter": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/match-sorter/-/match-sorter-6.3.0.tgz",
+      "integrity": "sha512-efYOf/wUpNb8FgNY+cOD2EIJI1S5I7YPKsw0LBp7wqPh5pmMS6i/wr3ZWwfwrAw1NvqTA2KUReVRWDX84lUcOQ==",
+      "requires": {
+        "@babel/runtime": "^7.12.5",
+        "remove-accents": "0.4.2"
+      }
+    },
     "md5.js": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
@@ -40858,6 +40977,11 @@
         "braces": "^3.0.1",
         "picomatch": "^2.2.3"
       }
+    },
+    "microseconds": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/microseconds/-/microseconds-0.2.0.tgz",
+      "integrity": "sha512-n7DHHMjR1avBbSpsTBj6fmMGh2AGrifVV4e+WYc3Q9lO+xnSZ3NyhcBND3vzzatt05LFhoKFRxrIyklmLlUtyA=="
     },
     "miller-rabin": {
       "version": "4.0.1",
@@ -41277,6 +41401,14 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/nano-json-stream-parser/-/nano-json-stream-parser-0.1.2.tgz",
       "integrity": "sha1-DMj20OK2IrR5xA1JnEbWS3Vcb18="
+    },
+    "nano-time": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/nano-time/-/nano-time-1.0.0.tgz",
+      "integrity": "sha1-sFVPaa2J4i0JB/ehKwmTpdlhN+8=",
+      "requires": {
+        "big-integer": "^1.6.16"
+      }
     },
     "nanoid": {
       "version": "3.1.23",
@@ -41949,6 +42081,11 @@
         "define-properties": "^1.1.3",
         "es-abstract": "^1.18.2"
       }
+    },
+    "oblivious-set": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/oblivious-set/-/oblivious-set-1.0.0.tgz",
+      "integrity": "sha512-z+pI07qxo4c2CulUHCDf9lcqDlMSo72N/4rLUpRXf6fu+q8vjt8y0xS+Tlf8NTJDdTXHbdeO1n3MlbctwEoXZw=="
     },
     "oboe": {
       "version": "2.1.5",
@@ -44360,6 +44497,16 @@
         "warning": "^4.0.3"
       }
     },
+    "react-query": {
+      "version": "3.19.1",
+      "resolved": "https://registry.npmjs.org/react-query/-/react-query-3.19.1.tgz",
+      "integrity": "sha512-tMBVKlmWevPHYWgI8ZBEgsTulJXSuXsxDbxqANODRnPI+3hd5GRVcc7nNIYSUx3aaULt08rN3EhTMHyTcFUNJw==",
+      "requires": {
+        "@babel/runtime": "^7.5.5",
+        "broadcast-channel": "^3.4.1",
+        "match-sorter": "^6.0.2"
+      }
+    },
     "react-redux": {
       "version": "7.2.4",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.4.tgz",
@@ -45821,6 +45968,11 @@
       "version": "0.2.7",
       "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
       "integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk="
+    },
+    "remove-accents": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.4.2.tgz",
+      "integrity": "sha1-CkPTqq4egNuRngeuJUsoXZ4ce7U="
     },
     "remove-trailing-separator": {
       "version": "1.1.0",
@@ -48859,6 +49011,15 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
       "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
+    },
+    "unload": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/unload/-/unload-2.2.0.tgz",
+      "integrity": "sha512-B60uB5TNBLtN6/LsgAf3udH9saB5p7gqJwcFfbOEZ8BcBHnGwCf6G/TGiEqkRAxX7zAFIUtzdrXQSdL3Q/wqNA==",
+      "requires": {
+        "@babel/runtime": "^7.6.2",
+        "detect-node": "^2.0.4"
+      }
     },
     "unpipe": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "react-lines-ellipsis": "^0.15.0",
     "react-media": "^1.10.0",
     "react-modal": "^3.13.1",
+    "react-query": "^3.19.1",
     "react-redux": "^7.2.4",
     "react-router-dom": "^5.2.0",
     "react-scripts": "4.0.3",

--- a/src/components/governance/hooks/useGovernanceProposals.ts
+++ b/src/components/governance/hooks/useGovernanceProposals.ts
@@ -3,6 +3,7 @@ import {
   SnapshotProposalResponse,
   SnapshotType,
 } from '@openlaw/snapshot-js-erc712';
+import {useQuery} from 'react-query';
 
 import {AsyncStatus} from '../../../util/types';
 import {BURN_ADDRESS} from '../../../util/constants';
@@ -48,13 +49,25 @@ export function useGovernanceProposals({
 
   const {isMountedRef} = useIsMounted();
 
+  const {
+    data: snapshotProposalEntriesData,
+    error: snapshotProposalEntriesError,
+  } = useQuery(
+    ['snapshotProposalEntries', actionId],
+    async () => await getSnapshotProposalsByActionId(actionId),
+    {
+      enabled: !!actionId,
+    }
+  );
+
   /**
    * Cached callbacks
    */
 
   const handleGetProposalsCached = useCallback(handleGetProposals, [
-    actionId,
     isMountedRef,
+    snapshotProposalEntriesData,
+    snapshotProposalEntriesError,
   ]);
 
   /**
@@ -119,14 +132,16 @@ export function useGovernanceProposals({
     try {
       setGovernanceProposalsStatus(AsyncStatus.PENDING);
 
-      const snapshotProposalEntries = await getSnapshotProposalsByActionId(
-        actionId
-      );
+      if (snapshotProposalEntriesError) {
+        throw snapshotProposalEntriesError;
+      }
 
-      if (!isMountedRef.current) return;
+      if (snapshotProposalEntriesData) {
+        if (!isMountedRef.current) return;
 
-      setGovernanceProposalsStatus(AsyncStatus.FULFILLED);
-      setGovernanceProposals(snapshotProposalEntries);
+        setGovernanceProposalsStatus(AsyncStatus.FULFILLED);
+        setGovernanceProposals(snapshotProposalEntriesData);
+      }
     } catch (error) {
       if (!isMountedRef.current) return;
 

--- a/src/components/governance/hooks/useGovernanceProposals.ts
+++ b/src/components/governance/hooks/useGovernanceProposals.ts
@@ -49,6 +49,10 @@ export function useGovernanceProposals({
 
   const {isMountedRef} = useIsMounted();
 
+  /**
+   * React Query
+   */
+
   const {
     data: snapshotProposalEntriesData,
     error: snapshotProposalEntriesError,

--- a/src/components/governance/hooks/useGovernanceProposals.unit.test.ts
+++ b/src/components/governance/hooks/useGovernanceProposals.unit.test.ts
@@ -6,6 +6,7 @@ import {rest, server} from '../../../test/server';
 import {SNAPSHOT_HUB_API_URL} from '../../../config';
 import {snapshotAPIProposalResponse} from '../../../test/restResponses';
 import {useGovernanceProposals} from './useGovernanceProposals';
+import Wrapper from '../../../test/Wrapper';
 
 describe('useGovernanceProposals unit tests', () => {
   test('should return correct data', async () => {
@@ -19,26 +20,34 @@ describe('useGovernanceProposals unit tests', () => {
         ]
       );
 
-      const {result, waitForNextUpdate} = await renderHook(() =>
-        useGovernanceProposals({actionId: BURN_ADDRESS})
+      const {result, waitForValueToChange} = await renderHook(
+        () => useGovernanceProposals({actionId: BURN_ADDRESS}),
+        {wrapper: Wrapper}
       );
 
+      // Assert initial state
       expect(result.current.governanceProposals).toMatchObject([]);
       expect(result.current.governanceProposalsError).toBe(undefined);
       expect(result.current.governanceProposalsStatus).toBe(
         AsyncStatus.STANDBY
       );
 
-      await waitForNextUpdate();
+      await waitForValueToChange(
+        () => result.current.governanceProposalsStatus
+      );
 
+      // Assert pending state
       expect(result.current.governanceProposals).toMatchObject([]);
       expect(result.current.governanceProposalsError).toBe(undefined);
       expect(result.current.governanceProposalsStatus).toBe(
         AsyncStatus.PENDING
       );
 
-      await waitForNextUpdate();
+      await waitForValueToChange(
+        () => result.current.governanceProposalsStatus
+      );
 
+      // Assert fulfilled state
       expect(
         result.current.governanceProposals[0].snapshotProposal
       ).toMatchObject({
@@ -64,26 +73,34 @@ describe('useGovernanceProposals unit tests', () => {
         ]
       );
 
-      const {result, waitForNextUpdate} = await renderHook(() =>
-        useGovernanceProposals({actionId: BURN_ADDRESS})
+      const {result, waitForValueToChange} = await renderHook(
+        () => useGovernanceProposals({actionId: BURN_ADDRESS}),
+        {wrapper: Wrapper}
       );
 
+      // Assert initial state
       expect(result.current.governanceProposals).toMatchObject([]);
       expect(result.current.governanceProposalsError).toBe(undefined);
       expect(result.current.governanceProposalsStatus).toBe(
         AsyncStatus.STANDBY
       );
 
-      await waitForNextUpdate();
+      await waitForValueToChange(
+        () => result.current.governanceProposalsStatus
+      );
 
+      // Assert pending state
       expect(result.current.governanceProposals).toMatchObject([]);
       expect(result.current.governanceProposalsError).toBe(undefined);
       expect(result.current.governanceProposalsStatus).toBe(
         AsyncStatus.PENDING
       );
 
-      await waitForNextUpdate();
+      await waitForValueToChange(
+        () => result.current.governanceProposalsStatus
+      );
 
+      // Assert rejected state
       expect(result.current.governanceProposals).toMatchObject([]);
       expect(result.current.governanceProposalsError?.message).toMatch(
         /something went wrong while fetching the Snapshot proposals/i

--- a/src/components/proposals/hooks/useDaoProposals.ts
+++ b/src/components/proposals/hooks/useDaoProposals.ts
@@ -145,7 +145,10 @@ export function useDaoProposals(proposalIds: string[]): UseDaoProposalsReturn {
 
       const proposals = await queryClient.fetchQuery(
         ['daoProposals', calls],
-        async () => await multicall({calls, web3Instance})
+        async () => await multicall({calls, web3Instance}),
+        {
+          staleTime: 60000,
+        }
       );
 
       setDaoProposals(safeProposalIds.map((id, i) => [id, proposals[i]]));

--- a/src/components/proposals/hooks/useDaoProposals.ts
+++ b/src/components/proposals/hooks/useDaoProposals.ts
@@ -1,6 +1,5 @@
 import {useEffect, useState, useCallback} from 'react';
 import {useSelector} from 'react-redux';
-import Web3 from 'web3';
 import {useQuery} from 'react-query';
 
 import {AsyncStatus} from '../../../util/types';
@@ -66,17 +65,22 @@ export function useDaoProposals(proposalIds: string[]): UseDaoProposalsReturn {
   const {web3Instance} = useWeb3Modal();
 
   /**
-   * Their hooks
+   * React Query
    */
 
   const {data: daoProposalsData, error: daoProposalsQueryError} = useQuery(
     ['daoProposals', daoProposalsCalls],
-    async () =>
-      await multicall({
-        calls: daoProposalsCalls as MulticallTuple[],
-        web3Instance: web3Instance as Web3,
-      }),
-    {enabled: !!daoProposalsCalls && !!web3Instance}
+    async () => {
+      if (!daoProposalsCalls?.length || !web3Instance) {
+        return;
+      }
+
+      return await multicall({
+        calls: daoProposalsCalls,
+        web3Instance,
+      });
+    },
+    {enabled: !!daoProposalsCalls?.length && !!web3Instance}
   );
 
   /**

--- a/src/components/proposals/hooks/useDaoProposals.ts
+++ b/src/components/proposals/hooks/useDaoProposals.ts
@@ -1,7 +1,6 @@
 import {useEffect, useState, useCallback} from 'react';
 import {useSelector} from 'react-redux';
 import Web3 from 'web3';
-import {AbiItem} from 'web3-utils/types';
 import {useQuery} from 'react-query';
 
 import {AsyncStatus} from '../../../util/types';
@@ -85,7 +84,6 @@ export function useDaoProposals(proposalIds: string[]): UseDaoProposalsReturn {
    */
 
   const handleGetDaoProposalsCached = useCallback(handleGetDaoProposals, [
-    daoProposalsCalls,
     daoProposalsData,
     daoProposalsQueryError,
     safeProposalIds,
@@ -98,6 +96,7 @@ export function useDaoProposals(proposalIds: string[]): UseDaoProposalsReturn {
   useEffect(() => {
     if (
       !proposalIds.length ||
+      !safeProposalIds ||
       !proposalsAbi ||
       !registryAddress ||
       !web3Instance
@@ -105,17 +104,13 @@ export function useDaoProposals(proposalIds: string[]): UseDaoProposalsReturn {
       return;
     }
 
-    handleGetDaoProposalsCached({
-      proposalIds,
-      proposalsAbi,
-      registryAddress,
-      web3Instance,
-    });
+    handleGetDaoProposalsCached();
   }, [
     handleGetDaoProposalsCached,
-    proposalIds,
+    proposalIds.length,
     proposalsAbi,
     registryAddress,
+    safeProposalIds,
     web3Instance,
   ]);
 
@@ -146,19 +141,9 @@ export function useDaoProposals(proposalIds: string[]): UseDaoProposalsReturn {
    * Functions
    */
 
-  async function handleGetDaoProposals({
-    proposalIds,
-    proposalsAbi,
-    registryAddress,
-    web3Instance,
-  }: {
-    proposalIds: string[];
-    proposalsAbi: AbiItem;
-    registryAddress: string;
-    web3Instance: Web3;
-  }) {
+  async function handleGetDaoProposals() {
     try {
-      if (!proposalIds.length || !safeProposalIds) return;
+      if (!safeProposalIds) return;
 
       if (!safeProposalIds.length) {
         setDaoProposalsStatus(AsyncStatus.FULFILLED);
@@ -170,8 +155,6 @@ export function useDaoProposals(proposalIds: string[]): UseDaoProposalsReturn {
       setDaoProposalsStatus(AsyncStatus.PENDING);
       // Reset error
       setDaoProposalsError(undefined);
-
-      if (!daoProposalsCalls) return;
 
       if (daoProposalsQueryError) {
         throw daoProposalsQueryError;

--- a/src/components/proposals/hooks/useDaoProposals.unit.test.ts
+++ b/src/components/proposals/hooks/useDaoProposals.unit.test.ts
@@ -303,12 +303,12 @@ describe('useDaoProposals unit tests', () => {
       );
 
       /**
-       * Inject mocked result for `proposals`
+       * Inject mocked error result for `proposals`
        *
-       * @todo Fix needing two injected errors to make test work.
+       * @todo Fix needing `injectResult` to make test work.
        */
 
-      mockWeb3Provider.injectError({code: 1234, message: 'Some RPC error!'});
+      mockWeb3Provider.injectResult(null);
       mockWeb3Provider.injectError({code: 1234, message: 'Some RPC error!'});
 
       await waitForValueToChange(() => result.current.daoProposalsStatus);
@@ -320,9 +320,9 @@ describe('useDaoProposals unit tests', () => {
         AsyncStatus.PENDING
       );
 
-      await waitForValueToChange(() => result.current.daoProposalsError);
+      await waitForValueToChange(() => result.current.daoProposalsStatus);
 
-      // Assert fulfilled
+      // Assert rejected
       expect(result.current.daoProposals).toStrictEqual([]);
       expect(result.current.daoProposalsError).toStrictEqual({
         code: 1234,

--- a/src/components/proposals/hooks/useOffchainVotingResults.ts
+++ b/src/components/proposals/hooks/useOffchainVotingResults.ts
@@ -106,7 +106,7 @@ export function useOffchainVotingResults(
               ];
             });
 
-            if (!voterEntries) return;
+            if (!voterEntries || !voterEntries.length) return;
 
             // Dedupe any duplicate addresses to be safe.
             const voterAddressesAndChoices = Object.entries(

--- a/src/components/proposals/hooks/useOffchainVotingResults.ts
+++ b/src/components/proposals/hooks/useOffchainVotingResults.ts
@@ -79,13 +79,21 @@ export function useOffchainVotingResults(
   const {isMountedRef} = useIsMounted();
 
   /**
-   * Their hooks
+   * React Query
    */
 
   const {data: votingResultsToSetData, error: votingResultsToSetError} =
     useQuery(
       ['votingResultsToSet', proposalsToMap],
       async () => {
+        if (
+          !bankAddress ||
+          !getPriorAmountABI ||
+          !proposalsToMap.length ||
+          !web3Instance
+        )
+          return;
+
         return await Promise.all(
           proposalsToMap.map(async (p) => {
             const snapshot = p?.msg.payload.snapshot;
@@ -115,11 +123,11 @@ export function useOffchainVotingResults(
 
             try {
               const result = await getUnitsPerChoiceCached({
-                bankAddress: bankAddress as string,
-                getPriorAmountABI: getPriorAmountABI as AbiItem,
+                bankAddress,
+                getPriorAmountABI,
                 snapshot,
                 voterAddressesAndChoices,
-                web3Instance: web3Instance as Web3,
+                web3Instance,
               });
 
               return [idInSnapshot, result];

--- a/src/components/proposals/hooks/useProposalOrDraft.ts
+++ b/src/components/proposals/hooks/useProposalOrDraft.ts
@@ -182,9 +182,9 @@ export function useProposalOrDraft(
     if (refetchCount === 0) return;
 
     /**
-     * Provide a different Array reference to force a re-render
-     * of the `useProposalsVotingAdapter` hook. If the `id` argument changes,
-     * that's fine as well, but it's unlikely.
+     * Provide a different Array reference to force a re-render of the
+     * `useProposalsVotingAdapter` hook. If the `id` argument changes, that's
+     * fine as well, but it's unlikely.
      */
     setProposalVotingAdapterId([id]);
   }, [id, refetchCount]);
@@ -194,9 +194,8 @@ export function useProposalOrDraft(
       if (refetchCount === 0) return;
 
       /**
-       * Reset queries when `refetchCount` is
-       * incremented (proposal is sponsored/submitted on chain, proposal is
-       * voted on)
+       * Reset queries when `refetchCount` is incremented (proposal is
+       * sponsored/submitted on chain, proposal is voted on)
        */
       await queryClient.resetQueries();
     }

--- a/src/components/proposals/hooks/useProposalOrDraft.ts
+++ b/src/components/proposals/hooks/useProposalOrDraft.ts
@@ -4,7 +4,6 @@ import {
   SnapshotProposalResponse,
   SnapshotType,
 } from '@openlaw/snapshot-js-erc712';
-import {useQuery} from 'react-query';
 
 import {
   Proposal,
@@ -29,65 +28,6 @@ type UseProposalReturn = {
 const ERROR_PROPOSAL: string =
   'Something went wrong while getting the proposal.';
 const ERROR_PROPOSAL_NOT_FOUND: string = 'Proposal was not found.';
-
-// Gets Draft (unsponsored Proposal) from Snapshot Hub
-async function getSnapshotDraftById(
-  id: string,
-  abortController?: AbortController
-) {
-  try {
-    const draft = await fetch(
-      `${SNAPSHOT_HUB_API_URL}/api/${SPACE}/draft/${id}`,
-      {signal: abortController?.signal}
-    );
-
-    if (!draft.ok) {
-      throw new Error(ERROR_PROPOSAL);
-    }
-
-    const draftJSON: SnapshotDraftResponse = await draft.json();
-
-    return draftJSON;
-  } catch (error) {
-    throw error;
-  }
-}
-
-// Gets Proposal from Snapshot Hub
-async function getSnapshotProposalById(
-  id: string,
-  abortController?: AbortController,
-  type?: ProposalOrDraftSnapshotType
-) {
-  try {
-    /**
-     * @note `searchUniqueDraftId` includes the draft id in the search for the proposal
-     *   as a Tribute proposal's ID hash could be the Snapshot Draft's ID.
-     */
-    const proposal = await fetch(
-      `${SNAPSHOT_HUB_API_URL}/api/${SPACE}/proposal/${id}?searchUniqueDraftId=true&includeVotes=true`,
-      {signal: abortController?.signal}
-    );
-
-    if (!proposal.ok) {
-      /**
-       * If `type` is set then we know we can determine `handleGetDraft`
-       * will not be called after in `handleGetProposalOrDraft`.
-       */
-      if (type === SnapshotType.proposal) {
-        throw new Error(ERROR_PROPOSAL);
-      }
-
-      return;
-    }
-
-    const proposalJSON: SnapshotProposalResponse = await proposal.json();
-
-    return proposalJSON;
-  } catch (error) {
-    throw error;
-  }
-}
 
 /**
  * useProposalOrDraft
@@ -144,33 +84,6 @@ export function useProposalOrDraft(
   const [refetchCount, updateRefetchCount] = useCounter();
 
   /**
-   * Their hooks
-   */
-
-  const {data: snapshotProposalEntryData, error: snapshotProposalEntryError} =
-    useQuery(
-      ['snapshotProposalEntry', id],
-      async () => await getSnapshotProposalById(id, abortController, type),
-      {
-        enabled: !!id && !!abortController?.signal,
-      }
-    );
-
-  const {data: snapshotDraftEntryData, error: snapshotDraftEntryError} =
-    useQuery(
-      ['snapshotDraftEntry', id],
-      async () => await getSnapshotDraftById(id, abortController),
-      {
-        enabled:
-          !!id &&
-          !!abortController?.signal &&
-          (type === SnapshotType.draft ||
-            (!!snapshotProposalEntryData &&
-              !Object.keys(snapshotProposalEntryData).length)),
-      }
-    );
-
-  /**
    * Fetch on-chain voting adapter data for proposals.
    * Only returns data for proposals of which voting adapters have been assigned (i.e. sponsored).
    */
@@ -185,15 +98,15 @@ export function useProposalOrDraft(
    */
 
   const handleGetDraftCached = useCallback(handleGetDraft, [
+    abortController?.signal,
+    id,
     isMountedRef,
-    snapshotDraftEntryData,
-    snapshotDraftEntryError,
   ]);
 
   const handleGetProposalCached = useCallback(handleGetProposal, [
+    abortController?.signal,
+    id,
     isMountedRef,
-    snapshotProposalEntryData,
-    snapshotProposalEntryError,
     type,
   ]);
 
@@ -344,33 +257,38 @@ export function useProposalOrDraft(
     try {
       setProposalStatus(AsyncStatus.PENDING);
 
-      if (snapshotDraftEntryError) {
-        throw snapshotDraftEntryError;
+      const response = await fetch(
+        `${SNAPSHOT_HUB_API_URL}/api/${SPACE}/draft/${id}`,
+        {signal: abortController?.signal}
+      );
+
+      if (!response.ok) {
+        throw new Error(ERROR_PROPOSAL);
       }
 
-      if (snapshotDraftEntryData) {
-        if (!isMountedRef.current) return;
+      const responseJSON: SnapshotDraftResponse = await response.json();
 
-        // @note API does not provide a 404
-        if (!Object.keys(snapshotDraftEntryData).length) {
-          setProposalNotFound(true);
+      if (!isMountedRef.current) return;
 
-          throw new Error(ERROR_PROPOSAL_NOT_FOUND);
-        }
+      // @note API does not provide a 404
+      if (!responseJSON || !Object.keys(responseJSON).length) {
+        setProposalNotFound(true);
 
-        const idKey = Object.keys(snapshotDraftEntryData)[0];
-        // Get the `SnapshotDraftResponseData` by the address key of the single result.
-        const draft: SnapshotDraft = {
-          idInDAO: idKey,
-          idInSnapshot: idKey,
-          ...snapshotDraftEntryData[idKey],
-        };
-
-        setProposalStatus(AsyncStatus.FULFILLED);
-        setSnapshotDraft(draft);
-
-        return draft;
+        throw new Error(ERROR_PROPOSAL_NOT_FOUND);
       }
+
+      const idKey = Object.keys(responseJSON)[0];
+      // Get the `SnapshotDraftResponseData` by the address key of the single result.
+      const draft: SnapshotDraft = {
+        idInDAO: idKey,
+        idInSnapshot: idKey,
+        ...responseJSON[idKey],
+      };
+
+      setProposalStatus(AsyncStatus.FULFILLED);
+      setSnapshotDraft(draft);
+
+      return draft;
     } catch (error) {
       if (!isMountedRef.current) return;
 
@@ -383,43 +301,60 @@ export function useProposalOrDraft(
     try {
       setProposalStatus(AsyncStatus.PENDING);
 
-      if (snapshotProposalEntryError) {
-        throw snapshotProposalEntryError;
-      }
+      /**
+       * @note `searchUniqueDraftId` includes the draft id in the search for the proposal
+       *   as a Tribute proposal's ID hash could be the Snapshot Draft's ID.
+       */
+      const response = await fetch(
+        `${SNAPSHOT_HUB_API_URL}/api/${SPACE}/proposal/${id}?searchUniqueDraftId=true&includeVotes=true`,
+        {signal: abortController?.signal}
+      );
 
-      if (snapshotProposalEntryData) {
-        if (!isMountedRef.current) return;
-
-        // @note API does not provide a 404
-        if (!Object.keys(snapshotProposalEntryData).length) {
-          /**
-           * If `type` is set then we know we can determine `handleGetDraft`
-           * will not be called after in `handleGetProposalOrDraft`.
-           */
-          if (type === SnapshotType.proposal) {
-            setProposalNotFound(true);
-            throw new Error(ERROR_PROPOSAL_NOT_FOUND);
-          }
-
-          return;
+      if (!response.ok) {
+        /**
+         * If `type` is set then we know we can determine `handleGetDraft`
+         * will not be called after in `handleGetProposalOrDraft`.
+         */
+        if (type === SnapshotType.proposal) {
+          throw new Error(ERROR_PROPOSAL);
         }
 
-        const idKey = Object.keys(snapshotProposalEntryData)[0];
-        // Determine ID submitted to DAO, i.e. if there's a Draft ID hash, we should use that.
-        const proposalId: string =
-          snapshotProposalEntryData[idKey]?.data.erc712DraftHash || idKey;
-        // Get the `SnapshotProposalResponseData` by the address key of the single result.
-        const proposal: SnapshotProposal = {
-          idInDAO: proposalId,
-          idInSnapshot: idKey,
-          ...snapshotProposalEntryData[idKey],
-        };
-
-        setProposalStatus(AsyncStatus.FULFILLED);
-        setSnapshotProposal(proposal);
-
-        return proposal;
+        return;
       }
+
+      const responseJSON: SnapshotProposalResponse = await response.json();
+
+      if (!isMountedRef.current) return;
+
+      // @note API does not provide a 404
+      if (!responseJSON || !Object.keys(responseJSON).length) {
+        /**
+         * If `type` is set then we know we can determine `handleGetDraft`
+         * will not be called after in `handleGetProposalOrDraft`.
+         */
+        if (type === SnapshotType.proposal) {
+          setProposalNotFound(true);
+          throw new Error(ERROR_PROPOSAL_NOT_FOUND);
+        }
+
+        return;
+      }
+
+      const idKey = Object.keys(responseJSON)[0];
+      // Determine ID submitted to DAO, i.e. if there's a Draft ID hash, we should use that.
+      const proposalId: string =
+        responseJSON[idKey]?.data.erc712DraftHash || idKey;
+      // Get the `SnapshotProposalResponseData` by the address key of the single result.
+      const proposal: SnapshotProposal = {
+        idInDAO: proposalId,
+        idInSnapshot: idKey,
+        ...responseJSON[idKey],
+      };
+
+      setProposalStatus(AsyncStatus.FULFILLED);
+      setSnapshotProposal(proposal);
+
+      return proposal;
     } catch (error) {
       if (!isMountedRef.current) return;
 

--- a/src/components/proposals/hooks/useProposalOrDraft.ts
+++ b/src/components/proposals/hooks/useProposalOrDraft.ts
@@ -194,8 +194,12 @@ export function useProposalOrDraft(
       if (refetchCount === 0) return;
 
       /**
-       * Reset queries when `refetchCount` is incremented (proposal is
+       * Reset React Queries when `refetchCount` is incremented (proposal is
        * sponsored/submitted on chain, proposal is voted on)
+       *
+       * Needed so queries can fetch data that has been updated by the change in
+       * proposal status
+       *
        */
       await queryClient.resetQueries();
     }

--- a/src/components/proposals/hooks/useProposalOrDraft.ts
+++ b/src/components/proposals/hooks/useProposalOrDraft.ts
@@ -265,8 +265,9 @@ export function useProposalOrDraft(
       if (refetchCount === 0) return;
 
       /**
-       *Refetch `snapshotProposalEntry` query when `refetchCount` is incremented
-       *(proposal is sponsored/submitted on chain, proposal is voted on)
+       * Refetch `snapshotProposalEntry` query when `refetchCount` is
+       * incremented (proposal is sponsored/submitted on chain, proposal is
+       * voted on)
        */
       await queryClient.invalidateQueries('snapshotProposalEntry');
 

--- a/src/components/proposals/hooks/useProposalOrDraft.ts
+++ b/src/components/proposals/hooks/useProposalOrDraft.ts
@@ -4,6 +4,7 @@ import {
   SnapshotProposalResponse,
   SnapshotType,
 } from '@openlaw/snapshot-js-erc712';
+import {useQuery} from 'react-query';
 
 import {
   Proposal,
@@ -28,6 +29,65 @@ type UseProposalReturn = {
 const ERROR_PROPOSAL: string =
   'Something went wrong while getting the proposal.';
 const ERROR_PROPOSAL_NOT_FOUND: string = 'Proposal was not found.';
+
+// Gets Draft (unsponsored Proposal) from Snapshot Hub
+async function getSnapshotDraftById(
+  id: string,
+  abortController?: AbortController
+) {
+  try {
+    const draft = await fetch(
+      `${SNAPSHOT_HUB_API_URL}/api/${SPACE}/draft/${id}`,
+      {signal: abortController?.signal}
+    );
+
+    if (!draft.ok) {
+      throw new Error(ERROR_PROPOSAL);
+    }
+
+    const draftJSON: SnapshotDraftResponse = await draft.json();
+
+    return draftJSON;
+  } catch (error) {
+    throw error;
+  }
+}
+
+// Gets Proposal from Snapshot Hub
+async function getSnapshotProposalById(
+  id: string,
+  abortController?: AbortController,
+  type?: ProposalOrDraftSnapshotType
+) {
+  try {
+    /**
+     * @note `searchUniqueDraftId` includes the draft id in the search for the proposal
+     *   as a Tribute proposal's ID hash could be the Snapshot Draft's ID.
+     */
+    const proposal = await fetch(
+      `${SNAPSHOT_HUB_API_URL}/api/${SPACE}/proposal/${id}?searchUniqueDraftId=true&includeVotes=true`,
+      {signal: abortController?.signal}
+    );
+
+    if (!proposal.ok) {
+      /**
+       * If `type` is set then we know we can determine `handleGetDraft`
+       * will not be called after in `handleGetProposalOrDraft`.
+       */
+      if (type === SnapshotType.proposal) {
+        throw new Error(ERROR_PROPOSAL);
+      }
+
+      return;
+    }
+
+    const proposalJSON: SnapshotProposalResponse = await proposal.json();
+
+    return proposalJSON;
+  } catch (error) {
+    throw error;
+  }
+}
 
 /**
  * useProposalOrDraft
@@ -84,6 +144,33 @@ export function useProposalOrDraft(
   const [refetchCount, updateRefetchCount] = useCounter();
 
   /**
+   * Their hooks
+   */
+
+  const {data: snapshotProposalEntryData, error: snapshotProposalEntryError} =
+    useQuery(
+      ['snapshotProposalEntry', id],
+      async () => await getSnapshotProposalById(id, abortController, type),
+      {
+        enabled: !!id && !!abortController?.signal,
+      }
+    );
+
+  const {data: snapshotDraftEntryData, error: snapshotDraftEntryError} =
+    useQuery(
+      ['snapshotDraftEntry', id],
+      async () => await getSnapshotDraftById(id, abortController),
+      {
+        enabled:
+          !!id &&
+          !!abortController?.signal &&
+          (type === SnapshotType.draft ||
+            (!!snapshotProposalEntryData &&
+              !Object.keys(snapshotProposalEntryData).length)),
+      }
+    );
+
+  /**
    * Fetch on-chain voting adapter data for proposals.
    * Only returns data for proposals of which voting adapters have been assigned (i.e. sponsored).
    */
@@ -98,15 +185,15 @@ export function useProposalOrDraft(
    */
 
   const handleGetDraftCached = useCallback(handleGetDraft, [
-    abortController?.signal,
-    id,
     isMountedRef,
+    snapshotDraftEntryData,
+    snapshotDraftEntryError,
   ]);
 
   const handleGetProposalCached = useCallback(handleGetProposal, [
-    abortController?.signal,
-    id,
     isMountedRef,
+    snapshotProposalEntryData,
+    snapshotProposalEntryError,
     type,
   ]);
 
@@ -257,38 +344,33 @@ export function useProposalOrDraft(
     try {
       setProposalStatus(AsyncStatus.PENDING);
 
-      const response = await fetch(
-        `${SNAPSHOT_HUB_API_URL}/api/${SPACE}/draft/${id}`,
-        {signal: abortController?.signal}
-      );
-
-      if (!response.ok) {
-        throw new Error(ERROR_PROPOSAL);
+      if (snapshotDraftEntryError) {
+        throw snapshotDraftEntryError;
       }
 
-      const responseJSON: SnapshotDraftResponse = await response.json();
+      if (snapshotDraftEntryData) {
+        if (!isMountedRef.current) return;
 
-      if (!isMountedRef.current) return;
+        // @note API does not provide a 404
+        if (!Object.keys(snapshotDraftEntryData).length) {
+          setProposalNotFound(true);
 
-      // @note API does not provide a 404
-      if (!responseJSON || !Object.keys(responseJSON).length) {
-        setProposalNotFound(true);
+          throw new Error(ERROR_PROPOSAL_NOT_FOUND);
+        }
 
-        throw new Error(ERROR_PROPOSAL_NOT_FOUND);
+        const idKey = Object.keys(snapshotDraftEntryData)[0];
+        // Get the `SnapshotDraftResponseData` by the address key of the single result.
+        const draft: SnapshotDraft = {
+          idInDAO: idKey,
+          idInSnapshot: idKey,
+          ...snapshotDraftEntryData[idKey],
+        };
+
+        setProposalStatus(AsyncStatus.FULFILLED);
+        setSnapshotDraft(draft);
+
+        return draft;
       }
-
-      const idKey = Object.keys(responseJSON)[0];
-      // Get the `SnapshotDraftResponseData` by the address key of the single result.
-      const draft: SnapshotDraft = {
-        idInDAO: idKey,
-        idInSnapshot: idKey,
-        ...responseJSON[idKey],
-      };
-
-      setProposalStatus(AsyncStatus.FULFILLED);
-      setSnapshotDraft(draft);
-
-      return draft;
     } catch (error) {
       if (!isMountedRef.current) return;
 
@@ -301,60 +383,43 @@ export function useProposalOrDraft(
     try {
       setProposalStatus(AsyncStatus.PENDING);
 
-      /**
-       * @note `searchUniqueDraftId` includes the draft id in the search for the proposal
-       *   as a Tribute proposal's ID hash could be the Snapshot Draft's ID.
-       */
-      const response = await fetch(
-        `${SNAPSHOT_HUB_API_URL}/api/${SPACE}/proposal/${id}?searchUniqueDraftId=true&includeVotes=true`,
-        {signal: abortController?.signal}
-      );
-
-      if (!response.ok) {
-        /**
-         * If `type` is set then we know we can determine `handleGetDraft`
-         * will not be called after in `handleGetProposalOrDraft`.
-         */
-        if (type === SnapshotType.proposal) {
-          throw new Error(ERROR_PROPOSAL);
-        }
-
-        return;
+      if (snapshotProposalEntryError) {
+        throw snapshotProposalEntryError;
       }
 
-      const responseJSON: SnapshotProposalResponse = await response.json();
+      if (snapshotProposalEntryData) {
+        if (!isMountedRef.current) return;
 
-      if (!isMountedRef.current) return;
+        // @note API does not provide a 404
+        if (!Object.keys(snapshotProposalEntryData).length) {
+          /**
+           * If `type` is set then we know we can determine `handleGetDraft`
+           * will not be called after in `handleGetProposalOrDraft`.
+           */
+          if (type === SnapshotType.proposal) {
+            setProposalNotFound(true);
+            throw new Error(ERROR_PROPOSAL_NOT_FOUND);
+          }
 
-      // @note API does not provide a 404
-      if (!responseJSON || !Object.keys(responseJSON).length) {
-        /**
-         * If `type` is set then we know we can determine `handleGetDraft`
-         * will not be called after in `handleGetProposalOrDraft`.
-         */
-        if (type === SnapshotType.proposal) {
-          setProposalNotFound(true);
-          throw new Error(ERROR_PROPOSAL_NOT_FOUND);
+          return;
         }
 
-        return;
+        const idKey = Object.keys(snapshotProposalEntryData)[0];
+        // Determine ID submitted to DAO, i.e. if there's a Draft ID hash, we should use that.
+        const proposalId: string =
+          snapshotProposalEntryData[idKey]?.data.erc712DraftHash || idKey;
+        // Get the `SnapshotProposalResponseData` by the address key of the single result.
+        const proposal: SnapshotProposal = {
+          idInDAO: proposalId,
+          idInSnapshot: idKey,
+          ...snapshotProposalEntryData[idKey],
+        };
+
+        setProposalStatus(AsyncStatus.FULFILLED);
+        setSnapshotProposal(proposal);
+
+        return proposal;
       }
-
-      const idKey = Object.keys(responseJSON)[0];
-      // Determine ID submitted to DAO, i.e. if there's a Draft ID hash, we should use that.
-      const proposalId: string =
-        responseJSON[idKey]?.data.erc712DraftHash || idKey;
-      // Get the `SnapshotProposalResponseData` by the address key of the single result.
-      const proposal: SnapshotProposal = {
-        idInDAO: proposalId,
-        idInSnapshot: idKey,
-        ...responseJSON[idKey],
-      };
-
-      setProposalStatus(AsyncStatus.FULFILLED);
-      setSnapshotProposal(proposal);
-
-      return proposal;
     } catch (error) {
       if (!isMountedRef.current) return;
 

--- a/src/components/proposals/hooks/useProposalWithOffchainVoteStatus.ts
+++ b/src/components/proposals/hooks/useProposalWithOffchainVoteStatus.ts
@@ -363,11 +363,11 @@ export function useProposalWithOffchainVoteStatus({
     atExistsInDAO,
     atProcessedInDAO,
     atSponsoredInDAO,
-    status,
     initialAsyncChecksCompleted,
     isInVoting,
     isInVotingGracePeriod,
     offchainResultSubmitted,
+    status,
   ]);
 
   /**

--- a/src/components/proposals/hooks/useProposals.ts
+++ b/src/components/proposals/hooks/useProposals.ts
@@ -459,12 +459,18 @@ export function useProposals({
 
       const snapshotDraftEntries = await queryClient.fetchQuery(
         ['snapshotDraftsByAdapterAddress', adapterAddress],
-        async () => await getSnapshotDraftsByAdapterAddress(adapterAddress)
+        async () => await getSnapshotDraftsByAdapterAddress(adapterAddress),
+        {
+          staleTime: 60000,
+        }
       );
 
       const snapshotProposalEntries = await queryClient.fetchQuery(
         ['snapshotProposalsByAdapterAddress', adapterAddress],
-        async () => await getSnapshotProposalsByAdapterAddress(adapterAddress)
+        async () => await getSnapshotProposalsByAdapterAddress(adapterAddress),
+        {
+          staleTime: 60000,
+        }
       );
 
       const mergedEntries = [

--- a/src/components/proposals/hooks/useProposals.ts
+++ b/src/components/proposals/hooks/useProposals.ts
@@ -197,14 +197,17 @@ export function useProposals({
     useProposalsVotes(proposalsVotingAdapters);
 
   /**
-   * Their hooks
+   * React Query
    */
 
   const {data: snapshotDraftEntriesData, error: snapshotDraftEntriesError} =
     useQuery(
       ['snapshotDraftEntries', adapterAddress],
-      async () =>
-        await getSnapshotDraftsByAdapterAddress(adapterAddress as string),
+      async () => {
+        if (!adapterAddress) return;
+
+        return await getSnapshotDraftsByAdapterAddress(adapterAddress);
+      },
       {
         enabled: !!adapterAddress,
       }
@@ -215,8 +218,11 @@ export function useProposals({
     error: snapshotProposalEntriesError,
   } = useQuery(
     ['snapshotProposalEntries', adapterAddress],
-    async () =>
-      await getSnapshotProposalsByAdapterAddress(adapterAddress as string),
+    async () => {
+      if (!adapterAddress) return;
+
+      return await getSnapshotProposalsByAdapterAddress(adapterAddress);
+    },
     {
       enabled: !!adapterAddress,
     }

--- a/src/components/proposals/hooks/useProposals.unit.test.ts
+++ b/src/components/proposals/hooks/useProposals.unit.test.ts
@@ -314,11 +314,8 @@ describe('useProposals unit tests', () => {
       await waitForValueToChange(() => result.current.proposalsStatus);
 
       // Assert fulfilled state
-      expect(result.current.proposals).toStrictEqual([]);
       expect(result.current.proposalsError).toBe(undefined);
       expect(result.current.proposalsStatus).toBe(AsyncStatus.FULFILLED);
-
-      await waitForValueToChange(() => result.current.proposals);
 
       // Assert Draft
 
@@ -556,6 +553,7 @@ describe('useProposals unit tests', () => {
     );
 
     await act(async () => {
+      // Assert initial state
       expect(result.current.proposals).toEqual([]);
       expect(result.current.proposalsError).toBe(undefined);
       expect(result.current.proposalsStatus).toBe(AsyncStatus.STANDBY);
@@ -757,17 +755,16 @@ describe('useProposals unit tests', () => {
 
       await waitForValueToChange(() => result.current.proposalsStatus);
 
+      // Assert pending state
       expect(result.current.proposals).toStrictEqual([]);
       expect(result.current.proposalsError).toBe(undefined);
       expect(result.current.proposalsStatus).toBe(AsyncStatus.PENDING);
 
       await waitForValueToChange(() => result.current.proposalsStatus);
 
-      expect(result.current.proposals).toStrictEqual([]);
+      // Assert fulfilled state
       expect(result.current.proposalsError).toBe(undefined);
       expect(result.current.proposalsStatus).toBe(AsyncStatus.FULFILLED);
-
-      await waitForValueToChange(() => result.current.proposals);
 
       // Assert Draft
 
@@ -1024,6 +1021,7 @@ describe('useProposals unit tests', () => {
     );
 
     await act(async () => {
+      // Assert initial state
       expect(result.current.proposals).toEqual([]);
       expect(result.current.proposalsError).toBe(undefined);
       expect(result.current.proposalsStatus).toBe(AsyncStatus.STANDBY);
@@ -1032,15 +1030,15 @@ describe('useProposals unit tests', () => {
 
       await waitForValueToChange(() => result.current.proposalsStatus);
 
+      // Assert pending state
       expect(result.current.proposals).toEqual([]);
       expect(result.current.proposalsError).toBe(undefined);
       expect(result.current.proposalsStatus).toBe(AsyncStatus.PENDING);
 
       await waitForValueToChange(() => result.current.proposalsStatus);
 
+      // Assert rejected state
       expect(result.current.proposalsStatus).toBe(AsyncStatus.REJECTED);
-
-      await waitForValueToChange(() => result.current.proposalsError);
 
       expect(result.current.proposalsError?.message).toMatch(
         /something went wrong while fetching the/i

--- a/src/components/proposals/hooks/useProposalsVotes.ts
+++ b/src/components/proposals/hooks/useProposalsVotes.ts
@@ -39,9 +39,6 @@ export function useProposalsVotes(
   const registryAddress = useSelector(
     (s: StoreState) => s.contracts.DaoRegistryContract?.contractAddress
   );
-  const registryABI = useSelector(
-    (s: StoreState) => s.contracts.DaoRegistryContract?.abi
-  );
 
   /**
    * State
@@ -93,7 +90,6 @@ export function useProposalsVotes(
       enabled:
         !!proposalVotingAdapters.length &&
         !!safeProposalVotingAdapters &&
-        !!registryABI &&
         !!registryAddress &&
         !!web3Instance,
     }
@@ -114,15 +110,11 @@ export function useProposalsVotes(
    */
 
   const getProposalsVotesOnchainCached = useCallback(getProposalsVotesOnchain, [
-    proposalVotingAdapters.length,
-    registryABI,
-    registryAddress,
     safeProposalVotingAdapters,
     votesDataCallsData,
     votesDataCallsError,
     votesDataResults,
     votesDataResultsError,
-    web3Instance,
   ]);
 
   /**
@@ -130,8 +122,23 @@ export function useProposalsVotes(
    */
 
   useEffect(() => {
+    if (
+      !proposalVotingAdapters.length ||
+      !safeProposalVotingAdapters ||
+      !registryAddress ||
+      !web3Instance
+    ) {
+      return;
+    }
+
     getProposalsVotesOnchainCached();
-  }, [getProposalsVotesOnchainCached]);
+  }, [
+    getProposalsVotesOnchainCached,
+    proposalVotingAdapters.length,
+    registryAddress,
+    safeProposalVotingAdapters,
+    web3Instance,
+  ]);
 
   useEffect(() => {
     if (!proposalVotingAdapters.length || !web3Instance) {
@@ -151,13 +158,7 @@ export function useProposalsVotes(
    */
 
   async function getProposalsVotesOnchain() {
-    if (
-      !proposalVotingAdapters.length ||
-      !safeProposalVotingAdapters ||
-      !registryABI ||
-      !registryAddress ||
-      !web3Instance
-    ) {
+    if (!safeProposalVotingAdapters) {
       return;
     }
 

--- a/src/components/proposals/hooks/useProposalsVotes.ts
+++ b/src/components/proposals/hooks/useProposalsVotes.ts
@@ -63,16 +63,16 @@ export function useProposalsVotes(
   const {web3Instance} = useWeb3Modal();
 
   /**
-   * Their hooks
+   * React Query
    */
 
   const {data: votesDataCallsData, error: votesDataCallsError} = useQuery(
     ['votesDataCalls', safeProposalVotingAdapters],
     async (): Promise<MulticallTuple[] | undefined> => {
-      if (!registryAddress) return;
+      if (!safeProposalVotingAdapters || !registryAddress) return;
 
       return await Promise.all(
-        (safeProposalVotingAdapters as ProposalVotingAdapterTuple[]).map(
+        safeProposalVotingAdapters.map(
           async ([
             proposalId,
             {votingAdapterAddress, getVotingAdapterABI, votingAdapterName},

--- a/src/components/proposals/hooks/useProposalsVotes.unit.test.ts
+++ b/src/components/proposals/hooks/useProposalsVotes.unit.test.ts
@@ -45,7 +45,7 @@ describe('useProposalsVotes unit tests', () => {
     ];
 
     await act(async () => {
-      const {result, waitForNextUpdate} = await renderHook(
+      const {result, waitForValueToChange} = await renderHook(
         () => useProposalsVotes(proposalsVotingAdapterTuples),
         {
           wrapper: Wrapper,
@@ -128,18 +128,21 @@ describe('useProposalsVotes unit tests', () => {
         }
       );
 
+      // Assert initial state
       expect(result.current.proposalsVotesStatus).toBe(AsyncStatus.STANDBY);
       expect(result.current.proposalsVotesError).toBe(undefined);
       expect(result.current.proposalsVotes).toMatchObject([]);
 
-      await waitForNextUpdate();
+      await waitForValueToChange(() => result.current.proposalsVotesStatus);
 
+      // Assert pending state
       expect(result.current.proposalsVotesStatus).toBe(AsyncStatus.PENDING);
       expect(result.current.proposalsVotesError).toBe(undefined);
       expect(result.current.proposalsVotes).toMatchObject([]);
 
-      await waitForNextUpdate();
+      await waitForValueToChange(() => result.current.proposalsVotesStatus);
 
+      // Assert fulfilled state
       expect(result.current.proposalsVotesStatus).toBe(AsyncStatus.FULFILLED);
       expect(result.current.proposalsVotesError).toBe(undefined);
       expect(result.current.proposalsVotes).toMatchObject([
@@ -289,12 +292,21 @@ describe('useProposalsVotes unit tests', () => {
         }
       );
 
+      // Assert initial state
       expect(result.current.proposalsVotesStatus).toBe(AsyncStatus.STANDBY);
       expect(result.current.proposalsVotesError).toBe(undefined);
       expect(result.current.proposalsVotes).toMatchObject([]);
 
       await waitForValueToChange(() => result.current.proposalsVotesStatus);
 
+      // Assert pending state
+      expect(result.current.proposalsVotesStatus).toBe(AsyncStatus.PENDING);
+      expect(result.current.proposalsVotesError).toBe(undefined);
+      expect(result.current.proposalsVotes).toMatchObject([]);
+
+      await waitForValueToChange(() => result.current.proposalsVotesStatus);
+
+      // Assert rejected state
       expect(result.current.proposalsVotesStatus).toBe(AsyncStatus.REJECTED);
       expect(result.current.proposalsVotesError?.message).toMatch(
         /no voting adapter name was found for "badvotingadaptername"/i
@@ -371,20 +383,23 @@ describe('useProposalsVotes unit tests', () => {
         }
       );
 
+      // Assert initial state
       expect(result.current.proposalsVotesStatus).toBe(AsyncStatus.STANDBY);
       expect(result.current.proposalsVotesError).toBe(undefined);
       expect(result.current.proposalsVotes).toMatchObject([]);
 
       await waitForValueToChange(() => result.current.proposalsVotesStatus);
 
+      // Assert pending state
       expect(result.current.proposalsVotesStatus).toBe(AsyncStatus.PENDING);
       expect(result.current.proposalsVotesError).toBe(undefined);
       expect(result.current.proposalsVotes).toMatchObject([]);
 
       await waitForValueToChange(() => result.current.proposalsVotesStatus);
 
+      // Assert fulfilled state
       expect(result.current.proposalsVotesStatus).toBe(AsyncStatus.FULFILLED);
-      expect(result.current.proposalsVotesError?.message).toBe(undefined);
+      expect(result.current.proposalsVotesError).toBe(undefined);
       expect(result.current.proposalsVotes).toMatchObject([
         [
           '0x4662dd46b8ca7ce0852426f20bc53b02335432089bbe3a4c510b36741d81ca75',
@@ -487,12 +502,14 @@ describe('useProposalsVotes unit tests', () => {
         }
       );
 
+      // Assert initial state
       expect(result.current.proposalsVotesStatus).toBe(AsyncStatus.STANDBY);
       expect(result.current.proposalsVotesError).toBe(undefined);
       expect(result.current.proposalsVotes).toMatchObject([]);
 
       await waitForValueToChange(() => result.current.proposalsVotesStatus);
 
+      // Assert fulfilled state
       expect(result.current.proposalsVotesStatus).toBe(AsyncStatus.FULFILLED);
       expect(result.current.proposalsVotesError).toBe(undefined);
       expect(result.current.proposalsVotes).toMatchObject([]);
@@ -558,6 +575,7 @@ describe('useProposalsVotes unit tests', () => {
         }
       );
 
+      // Assert initial state
       expect(result.current.proposalsVotesStatus).toBe(AsyncStatus.STANDBY);
       expect(result.current.proposalsVotesError).toBe(undefined);
       expect(result.current.proposalsVotes).toMatchObject([]);

--- a/src/components/proposals/hooks/useProposalsVotes.unit.test.ts
+++ b/src/components/proposals/hooks/useProposalsVotes.unit.test.ts
@@ -1,9 +1,11 @@
-import {act, renderHook} from '@testing-library/react-hooks';
 import {AbiItem} from 'web3-utils/types';
+import {act, renderHook} from '@testing-library/react-hooks';
+import Web3 from 'web3';
 
 import {
   DEFAULT_ETH_ADDRESS,
   DEFAULT_PROPOSAL_HASH,
+  FakeHttpProvider,
 } from '../../../test/helpers';
 import {AsyncStatus} from '../../../util/types';
 import {ProposalVotingAdapterData, ProposalVotingAdapterTuple} from '../types';
@@ -44,6 +46,9 @@ describe('useProposalsVotes unit tests', () => {
       ],
     ];
 
+    let mockWeb3Provider: FakeHttpProvider;
+    let web3Instance: Web3;
+
     await act(async () => {
       const {result, waitForValueToChange} = await renderHook(
         () => useProposalsVotes(proposalsVotingAdapterTuples),
@@ -52,79 +57,58 @@ describe('useProposalsVotes unit tests', () => {
           initialProps: {
             useInit: true,
             useWallet: true,
-            getProps: ({mockWeb3Provider, web3Instance}) => {
-              /**
-               * @note Maintain the same order as the contract's struct.
-               * @note We use the same, single result for any off-chain votes repsonses for testing only.
-               */
-              const offchainVotesDataResponse =
-                web3Instance.eth.abi.encodeParameter(
-                  {
-                    Voting: {
-                      snapshot: 'uint256',
-                      reporter: 'address',
-                      resultRoot: 'bytes32',
-                      nbYes: 'uint256',
-                      nbNo: 'uint256',
-                      startingTime: 'uint256',
-                      gracePeriodStartingTime: 'uint256',
-                      forceFailed: 'bool',
-                      isChallenged: 'bool',
-                      fallbackVotesCount: 'uint256',
-                    },
-                  },
-                  {
-                    snapshot: '8376297',
-                    reporter: '0xf9731Ad60BeCA05E9FB7aE8Dd4B63BFA49675b68',
-                    resultRoot:
-                      '0x9298a7fccdf7655408a8106ff03c9cbf0610082cc0f00dfe4c8f73f57a60df71',
-                    nbYes: '1',
-                    nbNo: '0',
-                    startingTime: '1617878162',
-                    gracePeriodStartingTime: '1617964640',
-                    forceFailed: false,
-                    isChallenged: false,
-                    fallbackVotesCount: '0',
-                  }
-                );
-
-              /**
-               * @note Maintain the same order as the contract's struct.
-               */
-              const onchainVotesDataResponse =
-                web3Instance.eth.abi.encodeParameter(
-                  {
-                    Voting: {
-                      nbYes: 'uint256',
-                      nbNo: 'uint256',
-                      startingTime: 'uint256',
-                      blockNumber: 'uint256',
-                    },
-                  },
-                  {
-                    blockNumber: '10',
-                    nbNo: '50',
-                    nbYes: '100',
-                    startingTime: '1617878162',
-                  }
-                );
-
-              // Mock votes data responses
-              mockWeb3Provider.injectResult(
-                web3Instance.eth.abi.encodeParameters(
-                  ['uint256', 'bytes[]'],
-                  [
-                    0,
-                    [
-                      offchainVotesDataResponse,
-                      offchainVotesDataResponse,
-                      onchainVotesDataResponse,
-                    ],
-                  ]
-                )
-              );
+            getProps: (p) => {
+              mockWeb3Provider = p.mockWeb3Provider;
+              web3Instance = p.web3Instance;
             },
           },
+        }
+      );
+
+      const offchainVotesDataResponse = web3Instance.eth.abi.encodeParameter(
+        {
+          Voting: {
+            snapshot: 'uint256',
+            reporter: 'address',
+            resultRoot: 'bytes32',
+            nbYes: 'uint256',
+            nbNo: 'uint256',
+            startingTime: 'uint256',
+            gracePeriodStartingTime: 'uint256',
+            forceFailed: 'bool',
+            isChallenged: 'bool',
+            fallbackVotesCount: 'uint256',
+          },
+        },
+        {
+          snapshot: '8376297',
+          reporter: '0xf9731Ad60BeCA05E9FB7aE8Dd4B63BFA49675b68',
+          resultRoot:
+            '0x9298a7fccdf7655408a8106ff03c9cbf0610082cc0f00dfe4c8f73f57a60df71',
+          nbYes: '1',
+          nbNo: '0',
+          startingTime: '1617878162',
+          gracePeriodStartingTime: '1617964640',
+          forceFailed: false,
+          isChallenged: false,
+          fallbackVotesCount: '0',
+        }
+      );
+
+      const onchainVotesDataResponse = web3Instance.eth.abi.encodeParameter(
+        {
+          Voting: {
+            nbYes: 'uint256',
+            nbNo: 'uint256',
+            startingTime: 'uint256',
+            blockNumber: 'uint256',
+          },
+        },
+        {
+          blockNumber: '10',
+          nbNo: '50',
+          nbYes: '100',
+          startingTime: '1617878162',
         }
       );
 
@@ -134,6 +118,21 @@ describe('useProposalsVotes unit tests', () => {
       expect(result.current.proposalsVotes).toMatchObject([]);
 
       await waitForValueToChange(() => result.current.proposalsVotesStatus);
+
+      // Mock votes data responses
+      mockWeb3Provider.injectResult(
+        web3Instance.eth.abi.encodeParameters(
+          ['uint256', 'bytes[]'],
+          [
+            0,
+            [
+              offchainVotesDataResponse,
+              offchainVotesDataResponse,
+              onchainVotesDataResponse,
+            ],
+          ]
+        )
+      );
 
       // Assert pending state
       expect(result.current.proposalsVotesStatus).toBe(AsyncStatus.PENDING);
@@ -244,50 +243,6 @@ describe('useProposalsVotes unit tests', () => {
           initialProps: {
             useInit: true,
             useWallet: true,
-            getProps: ({mockWeb3Provider, web3Instance}) => {
-              /**
-               * @note Maintain the same order as the contract's struct.
-               * @note We use the same, single result for any off-chain votes repsonses for testing only.
-               */
-              const offchainVotesDataResponse =
-                web3Instance.eth.abi.encodeParameter(
-                  {
-                    Voting: {
-                      snapshot: 'uint256',
-                      proposalHash: 'bytes32',
-                      reporter: 'address',
-                      resultRoot: 'bytes32',
-                      nbYes: 'uint256',
-                      nbNo: 'uint256',
-                      startingTime: 'uint256',
-                      gracePeriodStartingTime: 'uint256',
-                      isChallenged: 'bool',
-                      fallbackVotesCount: 'uint256',
-                    },
-                  },
-                  {
-                    snapshot: '8376297',
-                    proposalHash: DEFAULT_PROPOSAL_HASH,
-                    reporter: '0xf9731Ad60BeCA05E9FB7aE8Dd4B63BFA49675b68',
-                    resultRoot:
-                      '0x9298a7fccdf7655408a8106ff03c9cbf0610082cc0f00dfe4c8f73f57a60df71',
-                    nbYes: '1',
-                    nbNo: '0',
-                    startingTime: '1617878162',
-                    gracePeriodStartingTime: '1617964640',
-                    isChallenged: false,
-                    fallbackVotesCount: '0',
-                  }
-                );
-
-              // Mock votes data responses
-              mockWeb3Provider.injectResult(
-                web3Instance.eth.abi.encodeParameters(
-                  ['uint256', 'bytes[]'],
-                  [0, [offchainVotesDataResponse]]
-                )
-              );
-            },
           },
         }
       );
@@ -328,6 +283,9 @@ describe('useProposalsVotes unit tests', () => {
       ],
     ];
 
+    let mockWeb3Provider: FakeHttpProvider;
+    let web3Instance: Web3;
+
     await act(async () => {
       const {result, waitForValueToChange} = await renderHook(
         () => useProposalsVotes(proposalsVotingAdapterTuples),
@@ -336,50 +294,41 @@ describe('useProposalsVotes unit tests', () => {
           initialProps: {
             useInit: true,
             useWallet: true,
-            getProps: ({mockWeb3Provider, web3Instance}) => {
-              /**
-               * @note Maintain the same order as the contract's struct.
-               */
-              const offchainVotesDataResponse =
-                web3Instance.eth.abi.encodeParameter(
-                  {
-                    Voting: {
-                      snapshot: 'uint256',
-                      reporter: 'address',
-                      resultRoot: 'bytes32',
-                      nbYes: 'uint256',
-                      nbNo: 'uint256',
-                      startingTime: 'uint256',
-                      gracePeriodStartingTime: 'uint256',
-                      forceFailed: 'bool',
-                      isChallenged: 'bool',
-                      fallbackVotesCount: 'uint256',
-                    },
-                  },
-                  {
-                    snapshot: '8376297',
-                    reporter: '0xf9731Ad60BeCA05E9FB7aE8Dd4B63BFA49675b68',
-                    resultRoot:
-                      '0x9298a7fccdf7655408a8106ff03c9cbf0610082cc0f00dfe4c8f73f57a60df71',
-                    nbYes: '1',
-                    nbNo: '0',
-                    startingTime: '1617878162',
-                    gracePeriodStartingTime: '1617964640',
-                    forceFailed: false,
-                    isChallenged: false,
-                    fallbackVotesCount: '0',
-                  }
-                );
-
-              // Mock votes data responses
-              mockWeb3Provider.injectResult(
-                web3Instance.eth.abi.encodeParameters(
-                  ['uint256', 'bytes[]'],
-                  [0, [offchainVotesDataResponse]]
-                )
-              );
+            getProps: (p) => {
+              mockWeb3Provider = p.mockWeb3Provider;
+              web3Instance = p.web3Instance;
             },
           },
+        }
+      );
+
+      const offchainVotesDataResponse = web3Instance.eth.abi.encodeParameter(
+        {
+          Voting: {
+            snapshot: 'uint256',
+            reporter: 'address',
+            resultRoot: 'bytes32',
+            nbYes: 'uint256',
+            nbNo: 'uint256',
+            startingTime: 'uint256',
+            gracePeriodStartingTime: 'uint256',
+            forceFailed: 'bool',
+            isChallenged: 'bool',
+            fallbackVotesCount: 'uint256',
+          },
+        },
+        {
+          snapshot: '8376297',
+          reporter: '0xf9731Ad60BeCA05E9FB7aE8Dd4B63BFA49675b68',
+          resultRoot:
+            '0x9298a7fccdf7655408a8106ff03c9cbf0610082cc0f00dfe4c8f73f57a60df71',
+          nbYes: '1',
+          nbNo: '0',
+          startingTime: '1617878162',
+          gracePeriodStartingTime: '1617964640',
+          forceFailed: false,
+          isChallenged: false,
+          fallbackVotesCount: '0',
         }
       );
 
@@ -389,6 +338,14 @@ describe('useProposalsVotes unit tests', () => {
       expect(result.current.proposalsVotes).toMatchObject([]);
 
       await waitForValueToChange(() => result.current.proposalsVotesStatus);
+
+      // Mock votes data responses
+      mockWeb3Provider.injectResult(
+        web3Instance.eth.abi.encodeParameters(
+          ['uint256', 'bytes[]'],
+          [0, [offchainVotesDataResponse]]
+        )
+      );
 
       // Assert pending state
       expect(result.current.proposalsVotesStatus).toBe(AsyncStatus.PENDING);
@@ -455,49 +412,6 @@ describe('useProposalsVotes unit tests', () => {
           initialProps: {
             useInit: true,
             useWallet: true,
-            getProps: ({mockWeb3Provider, web3Instance}) => {
-              /**
-               * @note Maintain the same order as the contract's struct.
-               */
-              const offchainVotesDataResponse =
-                web3Instance.eth.abi.encodeParameter(
-                  {
-                    Voting: {
-                      snapshot: 'uint256',
-                      proposalHash: 'bytes32',
-                      reporter: 'address',
-                      resultRoot: 'bytes32',
-                      nbYes: 'uint256',
-                      nbNo: 'uint256',
-                      startingTime: 'uint256',
-                      gracePeriodStartingTime: 'uint256',
-                      isChallenged: 'bool',
-                      fallbackVotesCount: 'uint256',
-                    },
-                  },
-                  {
-                    snapshot: '8376297',
-                    proposalHash: DEFAULT_PROPOSAL_HASH,
-                    reporter: '0xf9731Ad60BeCA05E9FB7aE8Dd4B63BFA49675b68',
-                    resultRoot:
-                      '0x9298a7fccdf7655408a8106ff03c9cbf0610082cc0f00dfe4c8f73f57a60df71',
-                    nbYes: '1',
-                    nbNo: '0',
-                    startingTime: '1617878162',
-                    gracePeriodStartingTime: '1617964640',
-                    isChallenged: false,
-                    fallbackVotesCount: '0',
-                  }
-                );
-
-              // Mock votes data responses
-              mockWeb3Provider.injectResult(
-                web3Instance.eth.abi.encodeParameters(
-                  ['uint256', 'bytes[]'],
-                  [0, [offchainVotesDataResponse]]
-                )
-              );
-            },
           },
         }
       );
@@ -528,49 +442,6 @@ describe('useProposalsVotes unit tests', () => {
           initialProps: {
             useInit: true,
             useWallet: true,
-            getProps: ({mockWeb3Provider, web3Instance}) => {
-              /**
-               * @note Maintain the same order as the contract's struct.
-               */
-              const offchainVotesDataResponse =
-                web3Instance.eth.abi.encodeParameter(
-                  {
-                    Voting: {
-                      snapshot: 'uint256',
-                      proposalHash: 'bytes32',
-                      reporter: 'address',
-                      resultRoot: 'bytes32',
-                      nbYes: 'uint256',
-                      nbNo: 'uint256',
-                      startingTime: 'uint256',
-                      gracePeriodStartingTime: 'uint256',
-                      isChallenged: 'bool',
-                      fallbackVotesCount: 'uint256',
-                    },
-                  },
-                  {
-                    snapshot: '8376297',
-                    proposalHash: DEFAULT_PROPOSAL_HASH,
-                    reporter: '0xf9731Ad60BeCA05E9FB7aE8Dd4B63BFA49675b68',
-                    resultRoot:
-                      '0x9298a7fccdf7655408a8106ff03c9cbf0610082cc0f00dfe4c8f73f57a60df71',
-                    nbYes: '1',
-                    nbNo: '0',
-                    startingTime: '1617878162',
-                    gracePeriodStartingTime: '1617964640',
-                    isChallenged: false,
-                    fallbackVotesCount: '0',
-                  }
-                );
-
-              // Mock votes data responses
-              mockWeb3Provider.injectResult(
-                web3Instance.eth.abi.encodeParameters(
-                  ['uint256', 'bytes[]'],
-                  [0, [offchainVotesDataResponse]]
-                )
-              );
-            },
           },
         }
       );

--- a/src/components/proposals/hooks/useProposalsVotingAdapter.ts
+++ b/src/components/proposals/hooks/useProposalsVotingAdapter.ts
@@ -1,5 +1,6 @@
 import {useCallback, useEffect, useState} from 'react';
 import {useSelector} from 'react-redux';
+import {useQueryClient} from 'react-query';
 
 import {AsyncStatus} from '../../../util/types';
 import {BURN_ADDRESS} from '../../../util/constants';
@@ -51,6 +52,12 @@ export function useProposalsVotingAdapter(
   const {web3Instance} = useWeb3Modal();
 
   /**
+   * Their hooks
+   */
+
+  const queryClient = useQueryClient();
+
+  /**
    * State
    */
 
@@ -70,7 +77,7 @@ export function useProposalsVotingAdapter(
 
   const getProposalsVotingAdaptersOnchainCached = useCallback(
     getProposalsVotingAdaptersOnchain,
-    [proposalIds, registryABI, registryAddress, web3Instance]
+    [proposalIds, queryClient, registryABI, registryAddress, web3Instance]
   );
 
   /**
@@ -125,10 +132,15 @@ export function useProposalsVotingAdapter(
 
       setProposalsVotingAdaptersStatus(AsyncStatus.PENDING);
 
-      const votingAdapterAddressResults: string[] = await multicall({
-        calls: votingAdapterCalls,
-        web3Instance,
-      });
+      const votingAdapterAddressResults: string[] =
+        await queryClient.fetchQuery(
+          ['votingAdapterAddressResults', votingAdapterCalls],
+          async () =>
+            await multicall({calls: votingAdapterCalls, web3Instance}),
+          {
+            staleTime: 60000,
+          }
+        );
 
       const {default: lazyIVotingABI} = await import(
         '../../../abis/IVoting.json'
@@ -177,35 +189,49 @@ export function useProposalsVotingAdapter(
           [],
         ]);
 
-      const adapterNameResults: VotingAdapterName[] = await multicall({
-        calls: votingAdapterNameCalls,
-        web3Instance,
-      });
-
-      const votingAdaptersToSet = await Promise.all(
-        filteredProposalIds.map(
-          async (id, i): Promise<ProposalVotingAdapterTuple> => {
-            const votingAdapterABI = await getVotingAdapterABI(
-              adapterNameResults[i]
-            );
-            const votingAdapterAddress = filteredVotingAdapterAddressResults[i];
-
-            return [
-              id,
-              {
-                votingAdapterName: adapterNameResults[i],
-                votingAdapterAddress,
-                getVotingAdapterABI: () => votingAdapterABI,
-                getWeb3VotingAdapterContract: <T>() =>
-                  new web3Instance.eth.Contract(
-                    votingAdapterABI,
-                    votingAdapterAddress
-                  ) as any as T,
-              },
-            ];
+      const adapterNameResults: VotingAdapterName[] =
+        await queryClient.fetchQuery(
+          ['adapterNameResults', votingAdapterNameCalls],
+          async () =>
+            await multicall({calls: votingAdapterNameCalls, web3Instance}),
+          {
+            staleTime: 60000,
           }
-        )
-      );
+        );
+
+      const votingAdaptersToSet: ProposalVotingAdapterTuple[] =
+        await queryClient.fetchQuery(
+          ['votingAdaptersToSet', filteredProposalIds],
+          async () =>
+            await Promise.all(
+              filteredProposalIds.map(
+                async (id, i): Promise<ProposalVotingAdapterTuple> => {
+                  const votingAdapterABI = await getVotingAdapterABI(
+                    adapterNameResults[i]
+                  );
+                  const votingAdapterAddress =
+                    filteredVotingAdapterAddressResults[i];
+
+                  return [
+                    id,
+                    {
+                      votingAdapterName: adapterNameResults[i],
+                      votingAdapterAddress,
+                      getVotingAdapterABI: () => votingAdapterABI,
+                      getWeb3VotingAdapterContract: <T>() =>
+                        new web3Instance.eth.Contract(
+                          votingAdapterABI,
+                          votingAdapterAddress
+                        ) as any as T,
+                    },
+                  ];
+                }
+              )
+            ),
+          {
+            staleTime: 60000,
+          }
+        );
 
       setProposalsVotingAdapters(votingAdaptersToSet);
       setProposalsVotingAdaptersStatus(AsyncStatus.FULFILLED);

--- a/src/components/proposals/hooks/useProposalsVotingState.ts
+++ b/src/components/proposals/hooks/useProposalsVotingState.ts
@@ -2,7 +2,6 @@ import {useCallback, useEffect, useState} from 'react';
 import {useSelector} from 'react-redux';
 import {AbiItem} from 'web3-utils/types';
 import {useQuery} from 'react-query';
-import Web3 from 'web3';
 
 import {AsyncStatus} from '../../../util/types';
 import {multicall, MulticallTuple} from '../../web3/helpers';
@@ -65,7 +64,7 @@ export function useProposalsVotingState(
   const {web3Instance} = useWeb3Modal();
 
   /**
-   * Their hooks
+   * React Query
    */
 
   const {
@@ -73,12 +72,17 @@ export function useProposalsVotingState(
     error: proposalsVotingStateResultError,
   } = useQuery(
     ['proposalsVotingStateResult', proposalsVotingStateCalls],
-    async () =>
-      await multicall({
-        calls: proposalsVotingStateCalls as MulticallTuple[],
-        web3Instance: web3Instance as Web3,
-      }),
-    {enabled: !!proposalsVotingStateCalls && !!web3Instance}
+    async () => {
+      if (!proposalsVotingStateCalls?.length || !web3Instance) {
+        return;
+      }
+
+      return await multicall({
+        calls: proposalsVotingStateCalls,
+        web3Instance,
+      });
+    },
+    {enabled: !!proposalsVotingStateCalls?.length && !!web3Instance}
   );
 
   /**

--- a/src/components/proposals/voting/OffchainVotingAction.tsx
+++ b/src/components/proposals/voting/OffchainVotingAction.tsx
@@ -217,7 +217,7 @@ export function OffchainVotingAction(
       });
 
       // Refetch to show the vote the user submitted
-      await refetchProposalOrDraft();
+      refetchProposalOrDraft();
     } catch (error) {
       setSubmitError(error);
     }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -10,6 +10,9 @@ import {
   NormalizedCacheObject,
   HttpLink,
 } from '@apollo/client';
+import {QueryClient, QueryClientProvider} from 'react-query';
+// @todo Remove react-query dev tools before merging
+import {ReactQueryDevtools} from 'react-query/devtools';
 
 import {
   ENVIRONMENT,
@@ -80,6 +83,15 @@ export const getApolloClient = (
     }),
   });
 
+// Create `QueryClient`
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      refetchOnWindowFocus: false,
+    },
+  },
+});
+
 if (root !== null) {
   render(
     <Provider store={store}>
@@ -96,15 +108,21 @@ if (root !== null) {
           }}
           providerOptions={WALLETCONNECT_PROVIDER_OPTIONS}>
           <ApolloProvider client={getApolloClient(store)}>
-            <Init
-              render={({error, isInitComplete}) =>
-                error ? (
-                  <App renderMainContent={() => <InitError error={error} />} />
-                ) : isInitComplete ? (
-                  <App />
-                ) : null
-              }
-            />
+            <QueryClientProvider client={queryClient}>
+              <Init
+                render={({error, isInitComplete}) =>
+                  error ? (
+                    <App
+                      renderMainContent={() => <InitError error={error} />}
+                    />
+                  ) : isInitComplete ? (
+                    <App />
+                  ) : null
+                }
+              />
+              {/* @todo Remove react-query dev tools before merging */}
+              <ReactQueryDevtools initialIsOpen={false} />
+            </QueryClientProvider>
           </ApolloProvider>
         </Web3ModalManager>
       </BrowserRouter>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -84,7 +84,7 @@ export const getApolloClient = (
   });
 
 // Create `QueryClient`
-export const queryClient = new QueryClient({
+const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
       refetchOnWindowFocus: false,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -11,8 +11,6 @@ import {
   HttpLink,
 } from '@apollo/client';
 import {QueryClient, QueryClientProvider} from 'react-query';
-// @todo Remove react-query dev tools before merging
-import {ReactQueryDevtools} from 'react-query/devtools';
 
 import {
   ENVIRONMENT,
@@ -120,8 +118,6 @@ if (root !== null) {
                   ) : null
                 }
               />
-              {/* @todo Remove react-query dev tools before merging */}
-              <ReactQueryDevtools initialIsOpen={false} />
             </QueryClientProvider>
           </ApolloProvider>
         </Web3ModalManager>

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,4 +1,4 @@
-import {queryClient} from './test/Wrapper';
+const {queryClient} = require('./test/Wrapper');
 
 // Adds jest-dom's custom assertions
 require('@testing-library/jest-dom/extend-expect');

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,3 +1,4 @@
+const {act} = require('@testing-library/react-hooks');
 const {queryClient} = require('./test/Wrapper');
 
 // Adds jest-dom's custom assertions
@@ -73,6 +74,7 @@ beforeAll(() => {
 // (which is important for test isolation):
 afterEach(() => {
   server.resetHandlers();
-  queryClient.clear();
+  // clear global cache
+  act(() => queryClient.clear());
 });
 afterAll(() => server.close());

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,3 +1,5 @@
+import {queryClient} from './test/Wrapper';
+
 // Adds jest-dom's custom assertions
 require('@testing-library/jest-dom/extend-expect');
 const path = require('path');
@@ -69,5 +71,8 @@ beforeAll(() => {
 // If you need to add a handler after calling setupServer for some specific test
 // this will remove that handler for the rest of them
 // (which is important for test isolation):
-afterEach(() => server.resetHandlers());
+afterEach(() => {
+  server.resetHandlers();
+  queryClient.clear();
+});
 afterAll(() => server.close());

--- a/src/test/Wrapper.tsx
+++ b/src/test/Wrapper.tsx
@@ -6,6 +6,7 @@ import {Provider} from 'react-redux';
 import {ApolloProvider} from '@apollo/react-hooks';
 import React, {useEffect, useMemo, useState} from 'react';
 import Web3 from 'web3';
+import {QueryClientProvider} from 'react-query';
 
 import {
   Web3ModalContext,
@@ -14,7 +15,7 @@ import {
 import {AsyncStatus} from '../util/types';
 import {CHAINS as mockChains, WALLETCONNECT_PROVIDER_OPTIONS} from '../config';
 import {DEFAULT_ETH_ADDRESS, FakeHttpProvider, getNewStore} from './helpers';
-import {getApolloClient} from '../index';
+import {getApolloClient, queryClient} from '../index';
 import {VotingAdapterName} from '../components/adapters-extensions/enums';
 import App from '../App';
 import Init from '../Init';
@@ -257,7 +258,9 @@ export default function Wrapper(
         value={web3ContextValues as Web3ModalContextValue}>
         <MemoryRouter initialEntries={locationEntries || [{pathname: '/'}]}>
           <ApolloProvider client={getApolloClient(store)}>
-            {renderChildren(props.children)}
+            <QueryClientProvider client={queryClient}>
+              {renderChildren(props.children)}
+            </QueryClientProvider>
           </ApolloProvider>
         </MemoryRouter>
       </Web3ModalContext.Provider>

--- a/src/test/Wrapper.tsx
+++ b/src/test/Wrapper.tsx
@@ -1,12 +1,12 @@
-import {Store} from 'redux';
+import {ApolloProvider} from '@apollo/react-hooks';
 import {MemoryRouter} from 'react-router-dom';
-import type {LocationDescriptor} from 'history';
 import {provider as Web3Provider} from 'web3-core/types';
 import {Provider} from 'react-redux';
-import {ApolloProvider} from '@apollo/react-hooks';
-import React, {useEffect, useMemo, useState} from 'react';
-import Web3 from 'web3';
 import {QueryClient, QueryClientProvider} from 'react-query';
+import {Store} from 'redux';
+import React, {useEffect, useMemo, useState} from 'react';
+import type {LocationDescriptor} from 'history';
+import Web3 from 'web3';
 
 import {
   Web3ModalContext,
@@ -54,15 +54,6 @@ type WrapperProps = {
   locationEntries?: LocationDescriptor[];
 };
 
-export const queryClient = new QueryClient({
-  defaultOptions: {
-    queries: {
-      // turns retries off to test error results
-      retry: false,
-    },
-  },
-});
-
 /**
  * Similar to our app code, `<Wrapper />` provides a wrapper for tests which need the following to run:
  *
@@ -87,8 +78,25 @@ export default function Wrapper(
 
   const [store] = useState<Store>(getNewStore());
   const [mockWeb3Provider] = useState<FakeHttpProvider>(new FakeHttpProvider());
+
   const [web3Instance] = useState<Web3>(
     new Web3(mockWeb3Provider as unknown as Web3Provider)
+  );
+
+  const [queryClient] = useState<QueryClient>(
+    new QueryClient({
+      defaultOptions: {
+        queries: {
+          /**
+           * Turn retries off for `react-query`,
+           * unless retries are set when using `useQuery`.
+           *
+           * @see https://react-query.tanstack.com/guides/testing#turn-off-retries
+           */
+          retry: false,
+        },
+      },
+    })
   );
 
   /**
@@ -168,25 +176,32 @@ export default function Wrapper(
    */
 
   useEffect(() => {
-    return () => {
+    return function cleanup() {
       // When `<Wrapper />` unmounts, restore the original function.
       getAdapterAddressMock.then((v) => v?.mockRestore());
     };
   }, [getAdapterAddressMock]);
 
   useEffect(() => {
-    return () => {
+    return function cleanup() {
       // When `<Wrapper />` unmounts, restore the original function.
       getExtensionAddressMock.then((v) => v?.mockRestore());
     };
   }, [getExtensionAddressMock]);
 
   useEffect(() => {
-    return () => {
+    return function cleanup() {
       // When `<Wrapper />` unmounts, restore the original function.
       getVotingAdapterNameMock.then((v) => v?.mockRestore());
     };
   }, [getVotingAdapterNameMock]);
+
+  // Clear `queryClient` cache on unmount
+  useEffect(() => {
+    return function cleanup() {
+      queryClient.clear();
+    };
+  }, [queryClient]);
 
   useEffect(() => {
     /**

--- a/src/test/Wrapper.tsx
+++ b/src/test/Wrapper.tsx
@@ -6,7 +6,7 @@ import {Provider} from 'react-redux';
 import {ApolloProvider} from '@apollo/react-hooks';
 import React, {useEffect, useMemo, useState} from 'react';
 import Web3 from 'web3';
-import {QueryClientProvider} from 'react-query';
+import {QueryClient, QueryClientProvider} from 'react-query';
 
 import {
   Web3ModalContext,
@@ -15,7 +15,7 @@ import {
 import {AsyncStatus} from '../util/types';
 import {CHAINS as mockChains, WALLETCONNECT_PROVIDER_OPTIONS} from '../config';
 import {DEFAULT_ETH_ADDRESS, FakeHttpProvider, getNewStore} from './helpers';
-import {getApolloClient, queryClient} from '../index';
+import {getApolloClient} from '../index';
 import {VotingAdapterName} from '../components/adapters-extensions/enums';
 import App from '../App';
 import Init from '../Init';
@@ -53,6 +53,15 @@ type WrapperProps = {
    */
   locationEntries?: LocationDescriptor[];
 };
+
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      // turns retries off
+      retry: false,
+    },
+  },
+});
 
 /**
  * Similar to our app code, `<Wrapper />` provides a wrapper for tests which need the following to run:

--- a/src/test/Wrapper.tsx
+++ b/src/test/Wrapper.tsx
@@ -57,7 +57,7 @@ type WrapperProps = {
 export const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
-      // turns retries off
+      // turns retries off to test error results
       retry: false,
     },
   },


### PR DESCRIPTION
Implements caching strategy for proposal data using React Query as part of #423. (The issue description covers more than what is addressed by this PR so it should not be closed with just these updates.)

🥳 **Adds**

 - `react-query` library to implement caching strategy for fetched proposal data (see #423 for more info)

✨ **Updates**

 - update tests to handle proposal data caching updates with `react-query`
 