### PR TITLE
London Hardfork: Removes `gasPrice` from transactions

### DIFF
--- a/src/components/adapters-extensions/AdapterOrExtensionManager.tsx
+++ b/src/components/adapters-extensions/AdapterOrExtensionManager.tsx
@@ -1,8 +1,14 @@
 import {useCallback, useEffect, useState} from 'react';
 import {useSelector} from 'react-redux';
 
-import {StoreState} from '../../store/types';
-import {AsyncStatus} from '../../util/types';
+import {
+  defaultAdaptersAndExtensions,
+  AdaptersAndExtensionsType,
+} from './config';
+import {
+  useAdaptersOrExtensions,
+  useInitAdapterExtensionContracts,
+} from './hooks';
 import {
   AddAdapterArguments,
   AddAdaptersArguments,
@@ -10,32 +16,17 @@ import {
   AdaptersOrExtensions,
 } from './types';
 
+import {AsyncStatus} from '../../util/types';
 import {DaoAdapterConstants, DaoExtensionConstants} from './enums';
-
-import {
-  defaultAdaptersAndExtensions,
-  AdaptersAndExtensionsType,
-} from './config';
-
 import {getAdapterOrExtensionId, getAccessControlLayer} from './helpers';
 import {getDaoState, DaoState} from '../web3/helpers';
+import {StoreState} from '../../store/types';
 import {truncateEthAddress} from '../../util/helpers';
-
-import {
-  useAdaptersOrExtensions,
-  useInitAdapterExtensionContracts,
-} from './hooks';
+import {useContractSend, useWeb3Modal, useIsDefaultChain} from '../web3/hooks';
 import {useDao, useMemberActionDisabled} from '../../hooks';
-import {
-  useContractSend,
-  useETHGasPrice,
-  useWeb3Modal,
-  useIsDefaultChain,
-} from '../web3/hooks';
-
 import AdapterExtensionSelectTarget from './AdapterOrExtensionSelectTarget';
-import ConfigurationModal from './ConfigurationModal';
 import Checkbox, {CheckboxSize} from '../common/Checkbox';
+import ConfigurationModal from './ConfigurationModal';
 import ErrorMessageWithDetails from '../common/ErrorMessageWithDetails';
 import FadeIn from '../common/FadeIn';
 import FinalizeModal from './FinalizeModal';
@@ -46,6 +37,7 @@ enum WhyDisableModalTitles {
   FINALIZED_REASON = 'Why is finalizing disabled?',
   CONFIGURATION_REASON = 'Why are configurations disabled?',
 }
+
 /**
  * AdapterOrExtensionManager()
  *
@@ -93,21 +85,24 @@ export default function AdapterOrExtensionManager() {
   >();
 
   /**
-   * Hooks
+   * Our hooks
    */
+
   const {defaultChainError} = useIsDefaultChain();
   const {connected, account, web3Instance} = useWeb3Modal();
   const {dao, gqlError} = useDao();
+
   const {
     adapterExtensionStatus,
     getAdapterOrExtensionFromRedux,
     registeredAdaptersOrExtensions,
     unRegisteredAdaptersOrExtensions,
   } = useAdaptersOrExtensions();
+
   const {initAdapterExtensionContract} = useInitAdapterExtensionContracts();
 
   const {txSend} = useContractSend();
-  const {fast: fastGasPrice} = useETHGasPrice();
+
   const {
     isDisabled,
     openWhyDisabledModal,
@@ -339,7 +334,6 @@ export default function AdapterOrExtensionManager() {
 
       const txArguments = {
         from: account || '',
-        ...(fastGasPrice ? {gasPrice: fastGasPrice} : null),
       };
 
       const txSendMethod =
@@ -447,7 +441,6 @@ export default function AdapterOrExtensionManager() {
 
       const txArguments = {
         from: account || '',
-        ...(fastGasPrice ? {gasPrice: fastGasPrice} : null),
       };
 
       // Execute contract call for `addAdapters`

--- a/src/components/adapters-extensions/ConfigurationForm.tsx
+++ b/src/components/adapters-extensions/ConfigurationForm.tsx
@@ -1,19 +1,18 @@
-import {useState} from 'react';
+import {AbiItem} from 'web3-utils/types';
 import {useForm} from 'react-hook-form';
 import {useSelector} from 'react-redux';
-import {AbiItem} from 'web3-utils/types';
+import {useState} from 'react';
 
-import {DaoAdapterConstants} from './enums';
 import {AdaptersOrExtensions} from './types';
-import {StoreState} from '../../store/types';
-import {Web3TxStatus} from '../web3/types';
+import {BURN_ADDRESS} from '../../util/constants';
+import {DaoAdapterConstants} from './enums';
 import {FormFieldErrors} from '../../util/enums';
 import {getValidationError} from '../../util/helpers';
-import {BURN_ADDRESS} from '../../util/constants';
-import {useContractSend, useETHGasPrice, useWeb3Modal} from '../web3/hooks';
-import {useAdaptersOrExtensions, useValidation} from './hooks';
 import {ParamInputType, ParamType} from './hooks/useValidation';
-
+import {StoreState} from '../../store/types';
+import {useAdaptersOrExtensions, useValidation} from './hooks';
+import {useContractSend, useWeb3Modal} from '../web3/hooks';
+import {Web3TxStatus} from '../web3/types';
 import ErrorMessageWithDetails from '../common/ErrorMessageWithDetails';
 import InputError from '../common/InputError';
 import Loader from '../feedback/Loader';
@@ -67,7 +66,7 @@ export default function ConfigurationForm({
   );
 
   /**
-   * Hooks
+   * Our hooks
    */
   const {
     txError,
@@ -76,10 +75,11 @@ export default function ConfigurationForm({
     txSend,
     txStatus,
   } = useContractSend();
-  const {fast: fastGasPrice} = useETHGasPrice();
-  const {connected, account} = useWeb3Modal();
+
   const {isParamInputValid, getFormFieldError, formatInputByType} =
     useValidation();
+
+  const {connected, account} = useWeb3Modal();
   const {getAdapterOrExtensionFromRedux} = useAdaptersOrExtensions();
 
   /**
@@ -111,6 +111,7 @@ export default function ConfigurationForm({
       txStatus === Web3TxStatus.PENDING) &&
     (configureAdapterStatus === Web3TxStatus.AWAITING_CONFIRM ||
       configureAdapterStatus === Web3TxStatus.PENDING);
+
   const isRemoveInProcess =
     (txStatus === Web3TxStatus.AWAITING_CONFIRM ||
       txStatus === Web3TxStatus.PENDING) &&
@@ -120,12 +121,14 @@ export default function ConfigurationForm({
   const isConfigureDone =
     txStatus === Web3TxStatus.FULFILLED &&
     configureAdapterStatus === Web3TxStatus.FULFILLED;
+
   const isRemoveDone =
     txStatus === Web3TxStatus.FULFILLED &&
     removeStatus === Web3TxStatus.FULFILLED;
 
   const isConfigureInProcessOrDone =
     (isConfigureInProcess || isConfigureDone) && txIsPromptOpen;
+
   const isRemoveInProcessOrDone =
     (isRemoveInProcess || isRemoveDone) && txIsPromptOpen;
 
@@ -152,7 +155,6 @@ export default function ConfigurationForm({
 
       const txArguments = {
         from: account || '',
-        ...(fastGasPrice ? {gasPrice: fastGasPrice} : null),
       };
 
       // Execute contract call to `removeExtension` or `replaceAdapter`
@@ -227,7 +229,6 @@ export default function ConfigurationForm({
 
       const txArguments = {
         from: account || '',
-        ...(fastGasPrice ? {gasPrice: fastGasPrice} : null),
       };
 
       setConfigureAdapterStatus(Web3TxStatus.AWAITING_CONFIRM);

--- a/src/components/adapters-extensions/FinalizeModal.tsx
+++ b/src/components/adapters-extensions/FinalizeModal.tsx
@@ -1,21 +1,20 @@
 import {useState} from 'react';
 import {useSelector} from 'react-redux';
 
+import {CycleEllipsis} from '../feedback';
 import {StoreState} from '../../store/types';
-import {Web3TxStatus} from '../web3/types';
-import {useContractSend, useETHGasPrice, useWeb3Modal} from '../web3/hooks';
-import {useDao} from '../../hooks';
 import {truncateEthAddress} from '../../util/helpers';
 import {TX_CYCLE_MESSAGES} from '../web3/config';
-
-import {CycleEllipsis} from '../feedback';
-import Modal from '../common/Modal';
-import Loader from '../feedback/Loader';
-import TimesSVG from '../../assets/svg/TimesSVG';
+import {useContractSend, useWeb3Modal} from '../web3/hooks';
+import {useDao} from '../../hooks';
+import {Web3TxStatus} from '../web3/types';
 import CycleMessage from '../feedback/CycleMessage';
-import EtherscanURL from '../web3/EtherscanURL';
 import ErrorMessageWithDetails from '../common/ErrorMessageWithDetails';
+import EtherscanURL from '../web3/EtherscanURL';
 import FadeIn from '../common/FadeIn';
+import Loader from '../feedback/Loader';
+import Modal from '../common/Modal';
+import TimesSVG from '../../assets/svg/TimesSVG';
 
 type FinalizeModalProps = {
   isOpen: boolean;
@@ -39,11 +38,12 @@ export default function FinalizeModal({
   );
 
   /**
-   * Hooks
+   * Our hooks
    */
+
   const {txError, txEtherscanURL, txIsPromptOpen, txSend, txStatus} =
     useContractSend();
-  const {fast: fastGasPrice} = useETHGasPrice();
+
   const {dao} = useDao();
   const {connected, account} = useWeb3Modal();
 
@@ -52,9 +52,11 @@ export default function FinalizeModal({
    */
   const TIMEOUT_INTERVAL = 3000;
   const isConnected = connected && account;
+
   const isInProcess =
     txStatus === Web3TxStatus.AWAITING_CONFIRM ||
     txStatus === Web3TxStatus.PENDING;
+
   const isDone = txStatus === Web3TxStatus.FULFILLED;
   const isInProcessOrDone = isInProcess || isDone || txIsPromptOpen;
   const finalizeError = submitError || txError;
@@ -129,7 +131,6 @@ export default function FinalizeModal({
 
       const txArguments = {
         from: account || '',
-        ...(fastGasPrice ? {gasPrice: fastGasPrice} : null),
       };
 
       // Execute contract call for `finalizeDao`

--- a/src/components/proposals/PostProcessActionTransfer.tsx
+++ b/src/components/proposals/PostProcessActionTransfer.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useState, useRef} from 'react';
+import {useEffect, useState, useRef} from 'react';
 import {useDispatch, useSelector} from 'react-redux';
 
 import {CycleEllipsis} from '../feedback';
@@ -6,7 +6,7 @@ import {getConnectedMember} from '../../store/actions';
 import {ProposalData, DistributionStatus} from './types';
 import {ReduxDispatch, StoreState} from '../../store/types';
 import {TX_CYCLE_MESSAGES} from '../web3/config';
-import {useContractSend, useETHGasPrice, useWeb3Modal} from '../web3/hooks';
+import {useContractSend, useWeb3Modal} from '../web3/hooks';
 import {useMemberActionDisabled} from '../../hooks';
 import {Web3TxStatus} from '../web3/types';
 import CycleMessage from '../feedback/CycleMessage';
@@ -66,13 +66,13 @@ export default function PostProcessActionTransfer(
 
   const {account, web3Instance} = useWeb3Modal();
   const {txEtherscanURL, txIsPromptOpen, txSend, txStatus} = useContractSend();
+
   const {
     isDisabled,
     openWhyDisabledModal,
     WhyDisabledModal,
     setOtherDisabledReasons,
   } = useMemberActionDisabled();
-  const {fast: fastGasPrice} = useETHGasPrice();
 
   /**
    * Their hooks
@@ -87,6 +87,7 @@ export default function PostProcessActionTransfer(
   const isInProcess =
     txStatus === Web3TxStatus.AWAITING_CONFIRM ||
     txStatus === Web3TxStatus.PENDING;
+
   const isDone = txStatus === Web3TxStatus.FULFILLED;
   const isInProcessOrDone = isInProcess || isDone || txIsPromptOpen;
   const areSomeDisabled = isDisabled || isInProcessOrDone;
@@ -104,9 +105,11 @@ export default function PostProcessActionTransfer(
         if (!snapshotProposal) {
           throw new Error('No Snapshot proposal was found.');
         }
+
         if (!daoRegistryContract) {
           throw new Error('No DAO Registry contract was found.');
         }
+
         if (!DistributeContract) {
           throw new Error('No DistributeContract found.');
         }
@@ -189,7 +192,6 @@ export default function PostProcessActionTransfer(
 
       const txArguments = {
         from: account || '',
-        ...(fastGasPrice ? {gasPrice: fastGasPrice} : null),
       };
 
       const tx = await txSend(

--- a/src/components/proposals/ProcessAction.tsx
+++ b/src/components/proposals/ProcessAction.tsx
@@ -7,7 +7,7 @@ import {getContractByAddress} from '../web3/helpers';
 import {ProposalData} from './types';
 import {ReduxDispatch, StoreState} from '../../store/types';
 import {TX_CYCLE_MESSAGES} from '../web3/config';
-import {useContractSend, useETHGasPrice, useWeb3Modal} from '../web3/hooks';
+import {useContractSend, useWeb3Modal} from '../web3/hooks';
 import {useMemberActionDisabled} from '../../hooks';
 import {Web3TxStatus} from '../web3/types';
 import CycleMessage from '../feedback/CycleMessage';
@@ -64,9 +64,9 @@ export default function ProcessAction(props: ProcessActionProps) {
 
   const {account, web3Instance} = useWeb3Modal();
   const {txEtherscanURL, txIsPromptOpen, txSend, txStatus} = useContractSend();
+
   const {isDisabled, openWhyDisabledModal, WhyDisabledModal} =
     useMemberActionDisabled(useMemberActionDisabledProps);
-  const {fast: fastGasPrice} = useETHGasPrice();
 
   /**
    * Their hooks
@@ -120,7 +120,6 @@ export default function ProcessAction(props: ProcessActionProps) {
 
       const txArguments = {
         from: account || '',
-        ...(fastGasPrice ? {gasPrice: fastGasPrice} : null),
       };
 
       const tx = await txSend(

--- a/src/components/proposals/ProcessActionMembership.tsx
+++ b/src/components/proposals/ProcessActionMembership.tsx
@@ -2,12 +2,12 @@ import {useState, useRef, useEffect, useCallback} from 'react';
 import {useDispatch, useSelector} from 'react-redux';
 
 import {CycleEllipsis} from '../feedback';
-import {useDaoTokenDetails} from '../dao-token/hooks';
 import {getConnectedMember} from '../../store/actions';
 import {ProposalData, SnapshotProposal} from './types';
 import {ReduxDispatch, StoreState} from '../../store/types';
 import {TX_CYCLE_MESSAGES} from '../web3/config';
-import {useContractSend, useETHGasPrice, useWeb3Modal} from '../web3/hooks';
+import {useContractSend, useWeb3Modal} from '../web3/hooks';
+import {useDaoTokenDetails} from '../dao-token/hooks';
 import {useMemberActionDisabled} from '../../hooks';
 import {Web3TxStatus} from '../web3/types';
 import CycleMessage from '../feedback/CycleMessage';
@@ -82,13 +82,14 @@ export default function ProcessActionMembership(
 
   const {account, web3Instance} = useWeb3Modal();
   const {txEtherscanURL, txIsPromptOpen, txSend, txStatus} = useContractSend();
+
   const {
     isDisabled,
     openWhyDisabledModal,
     WhyDisabledModal,
     setOtherDisabledReasons,
   } = useMemberActionDisabled(useMemberActionDisabledProps);
-  const {fast: fastGasPrice} = useETHGasPrice();
+
   const {daoTokenDetails} = useDaoTokenDetails();
 
   /**
@@ -211,7 +212,6 @@ export default function ProcessActionMembership(
       const txArguments = {
         from: account || '',
         value: membershipProposalAmount,
-        ...(fastGasPrice ? {gasPrice: fastGasPrice} : null),
       };
 
       const tx = await txSend(

--- a/src/components/proposals/ProcessActionTribute.tsx
+++ b/src/components/proposals/ProcessActionTribute.tsx
@@ -8,7 +8,7 @@ import {getConnectedMember} from '../../store/actions';
 import {ProposalData, SnapshotProposal} from './types';
 import {ReduxDispatch, StoreState} from '../../store/types';
 import {TX_CYCLE_MESSAGES} from '../web3/config';
-import {useContractSend, useETHGasPrice, useWeb3Modal} from '../web3/hooks';
+import {useContractSend, useWeb3Modal} from '../web3/hooks';
 import {useDaoTokenDetails} from '../dao-token/hooks';
 import {useMemberActionDisabled} from '../../hooks';
 import {Web3TxStatus} from '../web3/types';
@@ -108,7 +108,6 @@ export default function ProcessActionTribute(props: ProcessActionTributeProps) {
     setOtherDisabledReasons,
   } = useMemberActionDisabled(useMemberActionDisabledProps);
 
-  const {fast: fastGasPrice} = useETHGasPrice();
   const {daoTokenDetails} = useDaoTokenDetails();
 
   /**
@@ -257,7 +256,6 @@ export default function ProcessActionTribute(props: ProcessActionTributeProps) {
           ];
           const txArguments = {
             from: account || '',
-            ...(fastGasPrice ? {gasPrice: fastGasPrice} : null),
           };
 
           // Execute contract call for `approve`
@@ -307,7 +305,6 @@ export default function ProcessActionTribute(props: ProcessActionTributeProps) {
 
       const txArguments = {
         from: account || '',
-        ...(fastGasPrice ? {gasPrice: fastGasPrice} : null),
       };
 
       const tx = await txSend(

--- a/src/components/proposals/SponsorAction.tsx
+++ b/src/components/proposals/SponsorAction.tsx
@@ -1,15 +1,15 @@
 import React, {useState} from 'react';
 import {useSelector} from 'react-redux';
-
 import {
   prepareVoteProposalData,
   SnapshotType,
 } from '@openlaw/snapshot-js-erc712';
+
 import {getContractByAddress} from '../web3/helpers';
 import {ProposalData} from './types';
 import {StoreState} from '../../store/types';
 import {TX_CYCLE_MESSAGES} from '../web3/config';
-import {useContractSend, useETHGasPrice, useWeb3Modal} from '../web3/hooks';
+import {useContractSend, useWeb3Modal} from '../web3/hooks';
 import {useMemberActionDisabled} from '../../hooks';
 import {useSignAndSubmitProposal} from './hooks';
 import {Web3TxStatus} from '../web3/types';
@@ -62,8 +62,6 @@ export default function SponsorAction(props: SponsorActionProps) {
 
   const {proposalSignAndSendStatus, signAndSendProposal} =
     useSignAndSubmitProposal<SnapshotType.proposal>();
-
-  const {fast: fastGasPrice} = useETHGasPrice();
 
   /**
    * Variables
@@ -147,7 +145,6 @@ export default function SponsorAction(props: SponsorActionProps) {
 
       const txArguments = {
         from: account || '',
-        ...(fastGasPrice ? {gasPrice: fastGasPrice} : null),
       };
 
       await txSend(

--- a/src/components/proposals/SubmitAction.tsx
+++ b/src/components/proposals/SubmitAction.tsx
@@ -13,7 +13,7 @@ import {SPACE} from '../../config';
 import {StoreState} from '../../store/types';
 import {TX_CYCLE_MESSAGES, VOTE_CHOICES} from '../web3/config';
 import {useCheckApplicant, useSignAndSubmitProposal} from './hooks';
-import {useContractSend, useETHGasPrice, useWeb3Modal} from '../web3/hooks';
+import {useContractSend, useWeb3Modal} from '../web3/hooks';
 import {useMemberActionDisabled} from '../../hooks';
 import {Web3TxStatus} from '../web3/types';
 import CycleMessage from '../feedback/CycleMessage';
@@ -135,8 +135,6 @@ export default function SubmitAction(props: SubmitActionProps) {
 
   const {proposalSignAndSendStatus, signAndSendProposal} =
     useSignAndSubmitProposal<SnapshotType.proposal>();
-
-  const {fast: fastGasPrice} = useETHGasPrice();
 
   const {
     checkApplicantError,
@@ -295,7 +293,6 @@ export default function SubmitAction(props: SubmitActionProps) {
 
       const txArguments = {
         from: account || '',
-        ...(fastGasPrice ? {gasPrice: fastGasPrice} : null),
       };
 
       await txSend(

--- a/src/components/proposals/voting/OffchainOpRollupVotingSubmitResultAction.tsx
+++ b/src/components/proposals/voting/OffchainOpRollupVotingSubmitResultAction.tsx
@@ -29,7 +29,7 @@ import {PRIMARY_TYPE_ERC712, TX_CYCLE_MESSAGES} from '../../web3/config';
 import {ProposalData} from '../types';
 import {StoreState} from '../../../store/types';
 import {useMemberActionDisabled} from '../../../hooks';
-import {useWeb3Modal, useContractSend, useETHGasPrice} from '../../web3/hooks';
+import {useWeb3Modal, useContractSend} from '../../web3/hooks';
 import CycleMessage from '../../feedback/CycleMessage';
 import ErrorMessageWithDetails from '../../common/ErrorMessageWithDetails';
 import EtherscanURL from '../../web3/EtherscanURL';
@@ -104,8 +104,6 @@ export function OffchainOpRollupVotingSubmitResultAction(
 
   const {isDisabled, openWhyDisabledModal, WhyDisabledModal} =
     useMemberActionDisabled();
-
-  const {fast: fastGasPrice} = useETHGasPrice();
 
   /**
    * Variables
@@ -326,7 +324,6 @@ export function OffchainOpRollupVotingSubmitResultAction(
 
       const txArguments = {
         from: account || '',
-        ...(fastGasPrice ? {gasPrice: fastGasPrice} : null),
       };
 
       // Send the tx

--- a/src/hooks/useRedeemCoupon.ts
+++ b/src/hooks/useRedeemCoupon.ts
@@ -4,7 +4,6 @@ import {toChecksumAddress} from 'web3-utils';
 
 import {
   useContractSend,
-  useETHGasPrice,
   useIsDefaultChain,
   useWeb3Modal,
 } from '../components/web3/hooks';
@@ -69,7 +68,6 @@ export function useRedeemCoupon(): ReturnUseRedeemCoupon {
    * Our hooks
    */
 
-  const {fast: fastGasPrice} = useETHGasPrice();
   const {account, web3Instance} = useWeb3Modal();
   const {defaultChainError} = useIsDefaultChain();
   const {txError, txEtherscanURL, txIsPromptOpen, txSend, txStatus} =
@@ -139,7 +137,6 @@ export function useRedeemCoupon(): ReturnUseRedeemCoupon {
 
       const txArguments = {
         from: account || '',
-        ...(fastGasPrice ? {gasPrice: fastGasPrice} : null),
       };
 
       // Execute contract call for `redeemCoupon`

--- a/src/pages/members/Delegation.tsx
+++ b/src/pages/members/Delegation.tsx
@@ -3,29 +3,25 @@ import {useDispatch, useSelector} from 'react-redux';
 import {useForm} from 'react-hook-form';
 import {toChecksumAddress} from 'web3-utils';
 
-import {
-  useWeb3Modal,
-  useContractSend,
-  useETHGasPrice,
-} from '../../components/web3/hooks';
-import {Web3TxStatus} from '../../components/web3/types';
-import {TX_CYCLE_MESSAGES} from '../../components/web3/config';
-import EtherscanURL from '../../components/web3/EtherscanURL';
-import {FormFieldErrors} from '../../util/enums';
-import {isEthAddressValid} from '../../util/validation';
-import {getValidationError, truncateEthAddress} from '../../util/helpers';
 import {BURN_ADDRESS} from '../../util/constants';
-import {getConnectedMember} from '../../store/actions';
-import {ReduxDispatch, StoreState} from '../../store/types';
 import {CheckboxSize} from '../../components/common/Checkbox';
-import Loader from '../../components/feedback/Loader';
+import {FormFieldErrors} from '../../util/enums';
+import {getConnectedMember} from '../../store/actions';
+import {getValidationError, truncateEthAddress} from '../../util/helpers';
+import {isEthAddressValid} from '../../util/validation';
+import {ReduxDispatch, StoreState} from '../../store/types';
+import {TX_CYCLE_MESSAGES} from '../../components/web3/config';
+import {useWeb3Modal, useContractSend} from '../../components/web3/hooks';
+import {Web3TxStatus} from '../../components/web3/types';
 import CycleMessage from '../../components/feedback/CycleMessage';
+import ErrorMessageWithDetails from '../../components/common/ErrorMessageWithDetails';
+import EtherscanURL from '../../components/web3/EtherscanURL';
+import FadeIn from '../../components/common/FadeIn';
+import InputError from '../../components/common/InputError';
+import Loader from '../../components/feedback/Loader';
 import Modal from '../../components/common/Modal';
 import TimesSVG from '../../assets/svg/TimesSVG';
 import UserSVG from '../../assets/svg/UserSVG';
-import FadeIn from '../../components/common/FadeIn';
-import InputError from '../../components/common/InputError';
-import ErrorMessageWithDetails from '../../components/common/ErrorMessageWithDetails';
 
 enum DelegationStatus {
   DELEGATE_VOTES = 'Delegate Votes',
@@ -84,7 +80,7 @@ function DelegationModal({
    */
 
   const {account, web3Instance} = useWeb3Modal();
-  const {fast: fastGasPrice} = useETHGasPrice();
+
   const {txError, txEtherscanURL, txIsPromptOpen, txSend, txStatus} =
     useContractSend();
 
@@ -318,7 +314,6 @@ function DelegationModal({
 
       const txArguments = {
         from: account || '',
-        ...(fastGasPrice ? {gasPrice: fastGasPrice} : null),
       };
 
       // Execute contract call for `updateDelegateKey`
@@ -385,7 +380,6 @@ function DelegationModal({
 
       const txArguments = {
         from: account || '',
-        ...(fastGasPrice ? {gasPrice: fastGasPrice} : null),
       };
 
       // Execute contract call for `updateDelegateKey`

--- a/src/pages/transfers/CreateTransferProposal.tsx
+++ b/src/pages/transfers/CreateTransferProposal.tsx
@@ -10,18 +10,17 @@ import {useSelector} from 'react-redux';
 import {useState, useCallback, useEffect} from 'react';
 
 import {
+  useContractSend,
+  useIsDefaultChain,
+  useWeb3Modal,
+} from '../../components/web3/hooks';
+import {
   getValidationError,
   stripFormatNumber,
   formatNumber,
   formatDecimal,
   truncateEthAddress,
 } from '../../util/helpers';
-import {
-  useContractSend,
-  useETHGasPrice,
-  useIsDefaultChain,
-  useWeb3Modal,
-} from '../../components/web3/hooks';
 import {BURN_ADDRESS} from '../../util/constants';
 import {ContractAdapterNames, Web3TxStatus} from '../../components/web3/types';
 import {default as ERC20ABI} from '../../abis/ERC20.json';
@@ -100,9 +99,10 @@ export default function CreateTransferProposal() {
 
   const {defaultChainError} = useIsDefaultChain();
   const {connected, account, web3Instance} = useWeb3Modal();
-  const {fast: fastGasPrice} = useETHGasPrice();
+
   const {txError, txEtherscanURL, txIsPromptOpen, txSend, txStatus} =
     useContractSend();
+
   const {proposalData, proposalSignAndSendStatus, signAndSendProposal} =
     useSignAndSubmitProposal<SnapshotType.proposal>();
 
@@ -467,7 +467,6 @@ export default function CreateTransferProposal() {
 
       const txArguments = {
         from: account || '',
-        ...(fastGasPrice ? {gasPrice: fastGasPrice} : null),
       };
 
       // Execute contract call for `submitProposal`


### PR DESCRIPTION
Fixes #456

✨ **Updates**

 - Removes fast `gasPrice` from transaction arguments to allow the new updates in `web3@1.5.x` to automatically set the gas price.
 

