### PR TITLE
revert back to using `gasPrice` for transactions

### DIFF
--- a/src/components/adapters-extensions/AdapterOrExtensionManager.tsx
+++ b/src/components/adapters-extensions/AdapterOrExtensionManager.tsx
@@ -95,7 +95,7 @@ export default function AdapterOrExtensionManager() {
   const {defaultChainError} = useIsDefaultChain();
   const {connected, account, web3Instance} = useWeb3Modal();
   const {dao, gqlError} = useDao();
-  const {average: gasPrice} = useETHGasPrice({noRunIfEIP1559: true});
+  const {average: gasPrice} = useETHGasPrice();
 
   const {
     adapterExtensionStatus,

--- a/src/components/adapters-extensions/ConfigurationForm.tsx
+++ b/src/components/adapters-extensions/ConfigurationForm.tsx
@@ -82,7 +82,7 @@ export default function ConfigurationForm({
 
   const {connected, account} = useWeb3Modal();
   const {getAdapterOrExtensionFromRedux} = useAdaptersOrExtensions();
-  const {average: gasPrice} = useETHGasPrice({noRunIfEIP1559: true});
+  const {average: gasPrice} = useETHGasPrice();
 
   /**
    * Their hooks

--- a/src/components/adapters-extensions/FinalizeModal.tsx
+++ b/src/components/adapters-extensions/FinalizeModal.tsx
@@ -46,7 +46,7 @@ export default function FinalizeModal({
 
   const {dao} = useDao();
   const {connected, account} = useWeb3Modal();
-  const {average: gasPrice} = useETHGasPrice({noRunIfEIP1559: true});
+  const {average: gasPrice} = useETHGasPrice();
 
   /**
    * Variables

--- a/src/components/proposals/PostProcessActionTransfer.tsx
+++ b/src/components/proposals/PostProcessActionTransfer.tsx
@@ -66,7 +66,7 @@ export default function PostProcessActionTransfer(
 
   const {account, web3Instance} = useWeb3Modal();
   const {txEtherscanURL, txIsPromptOpen, txSend, txStatus} = useContractSend();
-  const {average: gasPrice} = useETHGasPrice({noRunIfEIP1559: true});
+  const {average: gasPrice} = useETHGasPrice();
 
   const {
     isDisabled,

--- a/src/components/proposals/ProcessAction.tsx
+++ b/src/components/proposals/ProcessAction.tsx
@@ -64,7 +64,7 @@ export default function ProcessAction(props: ProcessActionProps) {
 
   const {account, web3Instance} = useWeb3Modal();
   const {txEtherscanURL, txIsPromptOpen, txSend, txStatus} = useContractSend();
-  const {average: gasPrice} = useETHGasPrice({noRunIfEIP1559: true});
+  const {average: gasPrice} = useETHGasPrice();
 
   const {isDisabled, openWhyDisabledModal, WhyDisabledModal} =
     useMemberActionDisabled(useMemberActionDisabledProps);

--- a/src/components/proposals/ProcessActionMembership.tsx
+++ b/src/components/proposals/ProcessActionMembership.tsx
@@ -82,7 +82,7 @@ export default function ProcessActionMembership(
 
   const {account, web3Instance} = useWeb3Modal();
   const {txEtherscanURL, txIsPromptOpen, txSend, txStatus} = useContractSend();
-  const {average: gasPrice} = useETHGasPrice({noRunIfEIP1559: true});
+  const {average: gasPrice} = useETHGasPrice();
 
   const {
     isDisabled,

--- a/src/components/proposals/ProcessActionTribute.tsx
+++ b/src/components/proposals/ProcessActionTribute.tsx
@@ -93,7 +93,7 @@ export default function ProcessActionTribute(props: ProcessActionTributeProps) {
 
   const {account, web3Instance} = useWeb3Modal();
   const {txEtherscanURL, txIsPromptOpen, txSend, txStatus} = useContractSend();
-  const {average: gasPrice} = useETHGasPrice({noRunIfEIP1559: true});
+  const {average: gasPrice} = useETHGasPrice();
 
   const {
     txEtherscanURL: txEtherscanURLTokenApprove,

--- a/src/components/proposals/SponsorAction.tsx
+++ b/src/components/proposals/SponsorAction.tsx
@@ -55,7 +55,7 @@ export default function SponsorAction(props: SponsorActionProps) {
 
   const {account, web3Instance} = useWeb3Modal();
   const {txEtherscanURL, txIsPromptOpen, txSend, txStatus} = useContractSend();
-  const {average: gasPrice} = useETHGasPrice({noRunIfEIP1559: true});
+  const {average: gasPrice} = useETHGasPrice();
 
   const {isDisabled, openWhyDisabledModal, WhyDisabledModal} =
     useMemberActionDisabled();

--- a/src/components/proposals/SubmitAction.tsx
+++ b/src/components/proposals/SubmitAction.tsx
@@ -124,7 +124,7 @@ export default function SubmitAction(props: SubmitActionProps) {
 
   const {account, web3Instance} = useWeb3Modal();
   const {txEtherscanURL, txIsPromptOpen, txSend, txStatus} = useContractSend();
-  const {average: gasPrice} = useETHGasPrice({noRunIfEIP1559: true});
+  const {average: gasPrice} = useETHGasPrice();
 
   const {
     isDisabled,

--- a/src/components/proposals/voting/OffchainOpRollupVotingSubmitResultAction.tsx
+++ b/src/components/proposals/voting/OffchainOpRollupVotingSubmitResultAction.tsx
@@ -105,7 +105,7 @@ export function OffchainOpRollupVotingSubmitResultAction(
 
   const {account, provider, web3Instance} = useWeb3Modal();
   const {txEtherscanURL, txIsPromptOpen, txSend, txStatus} = useContractSend();
-  const {average: gasPrice} = useETHGasPrice({noRunIfEIP1559: true});
+  const {average: gasPrice} = useETHGasPrice();
 
   const {isDisabled, openWhyDisabledModal, WhyDisabledModal} =
     useMemberActionDisabled();

--- a/src/hooks/useRedeemCoupon.ts
+++ b/src/hooks/useRedeemCoupon.ts
@@ -71,7 +71,7 @@ export function useRedeemCoupon(): ReturnUseRedeemCoupon {
 
   const {account, web3Instance} = useWeb3Modal();
   const {defaultChainError} = useIsDefaultChain();
-  const {average: gasPrice} = useETHGasPrice({noRunIfEIP1559: true});
+  const {average: gasPrice} = useETHGasPrice();
 
   const {txError, txEtherscanURL, txIsPromptOpen, txSend, txStatus} =
     useContractSend();

--- a/src/pages/members/Delegation.tsx
+++ b/src/pages/members/Delegation.tsx
@@ -84,7 +84,7 @@ function DelegationModal({
    */
 
   const {account, web3Instance} = useWeb3Modal();
-  const {average: gasPrice} = useETHGasPrice({noRunIfEIP1559: true});
+  const {average: gasPrice} = useETHGasPrice();
 
   const {txError, txEtherscanURL, txIsPromptOpen, txSend, txStatus} =
     useContractSend();

--- a/src/pages/transfers/CreateTransferProposal.tsx
+++ b/src/pages/transfers/CreateTransferProposal.tsx
@@ -100,7 +100,7 @@ export default function CreateTransferProposal() {
 
   const {defaultChainError} = useIsDefaultChain();
   const {connected, account, web3Instance} = useWeb3Modal();
-  const {average: gasPrice} = useETHGasPrice({noRunIfEIP1559: true});
+  const {average: gasPrice} = useETHGasPrice();
 
   const {txError, txEtherscanURL, txIsPromptOpen, txSend, txStatus} =
     useContractSend();


### PR DESCRIPTION
Following on from changes in #460.

🐞 **Bugs squashed**

- Removes parameters from use in `useETHGasPrice` to revert back to using `gasPrice` for transactions. This should allow Trezor and Ledger wallets to work again with MetaMask as they do not support EIP-1559, yet. The initial fix did not work because MetaMask checks the wallet type && the network when determining EIP-1559 support. However, MetaMask probably does not change to a legacy network for those wallets.
