### PR TITLE
upgrade ManagingContract

### DIFF
--- a/src/abis/ManagingContract.json
+++ b/src/abis/ManagingContract.json
@@ -102,13 +102,18 @@
     "outputs": [
       {
         "internalType": "bytes32",
-        "name": "adapterId",
+        "name": "adapterOrExtensionId",
         "type": "bytes32"
       },
       {
         "internalType": "address",
-        "name": "adapterAddress",
+        "name": "adapterOrExtensionAddr",
         "type": "address"
+      },
+      {
+        "internalType": "enum IManaging.UpdateType",
+        "name": "updateType",
+        "type": "uint8"
       },
       {
         "internalType": "uint128",
@@ -168,33 +173,48 @@
         "components": [
           {
             "internalType": "bytes32",
-            "name": "adapterId",
+            "name": "adapterOrExtensionId",
             "type": "bytes32"
           },
           {
             "internalType": "address",
-            "name": "adapterAddress",
+            "name": "adapterOrExtensionAddr",
             "type": "address"
+          },
+          {
+            "internalType": "enum IManaging.UpdateType",
+            "name": "updateType",
+            "type": "uint8"
           },
           {
             "internalType": "uint128",
             "name": "flags",
             "type": "uint128"
+          },
+          {
+            "internalType": "bytes32[]",
+            "name": "keys",
+            "type": "bytes32[]"
+          },
+          {
+            "internalType": "uint256[]",
+            "name": "values",
+            "type": "uint256[]"
+          },
+          {
+            "internalType": "address[]",
+            "name": "extensionAddresses",
+            "type": "address[]"
+          },
+          {
+            "internalType": "uint128[]",
+            "name": "extensionAclFlags",
+            "type": "uint128[]"
           }
         ],
-        "internalType": "struct IManaging.ProposalInput",
+        "internalType": "struct IManaging.ProposalDetails",
         "name": "proposal",
         "type": "tuple"
-      },
-      {
-        "internalType": "bytes32[]",
-        "name": "keys",
-        "type": "bytes32[]"
-      },
-      {
-        "internalType": "uint256[]",
-        "name": "values",
-        "type": "uint256[]"
       },
       {
         "internalType": "bytes",


### PR DESCRIPTION
✨ **Updates**

 - updates ABI for upgraded `ManagingContract` adapter from https://github.com/openlawteam/tribute-contracts/releases/tag/v1.0.2

Note: This PR will be merged as part of upgrading the `ManagingContract` for all the deployed Tribute DAOs.
 