### PR TITLE
chore: dockerfile + docker-build workflow

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+Dockerfile
+.vscode
+.github
+node_modules
+.gitignore

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -1,0 +1,39 @@
+name: DockerHub Build 
+
+on:
+  push:
+    branches:
+      - main
+
+env:
+  DOCKER_REPO: openlaw/tribute-ui
+  IMAGE_NAME: openlaw/tribute-ui
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check available environment variables
+        uses: actions/checkout@v2
+
+      - name: Inject slug/short variables
+        uses: rlespinasse/github-slug-action@v3.x
+
+      - name: Setup SSH to install dependencies
+        uses: webfactory/ssh-agent@v0.5.0
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+      
+      - name: Build docker image and tag
+        uses: docker/build-push-action@v1
+        env:
+          DOCKER_BUILDKIT: 1
+        with:
+          username: ${{ secrets.PUB_REPO_DOCKERHUB_USERNAME }}
+          password: ${{ secrets.PUB_REPO_DOCKERHUB_ACCESS_TOKEN }}
+          repository: ${{ env.DOCKER_REPO }}
+          # Automatically tags the built image with the git short SHA 
+          # prefixed with the branch name, e.g: main-xxxxxxx
+          tags: ${{ env.GITHUB_REF_SLUG }}-${{ env.GITHUB_SHA_SHORT }}
+          # Only push on git main branch
+          push: ${{ startsWith(github.ref, 'refs/heads/main') }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+
+# Node version matching the version declared in the package.json 
+FROM node:14.17.6-alpine as build
+RUN apk add git openssh-client
+RUN mkdir -p -m 0600 ~/.ssh && ssh-keyscan github.com >> ~/.ssh/known_hosts
+RUN npm install -g npm@7.24.0
+
+# Created the app work dir
+WORKDIR /app
+
+# Add node to $PATH
+ENV PATH /app/node_modules/.bin:$PATH
+
+# Copy app configs
+COPY . ./
+
+# Install app dependencies
+RUN npm ci
+
+# Build app
+RUN npm run build
+
+# Start the aplication
+CMD ["npm", "start"]


### PR DESCRIPTION
🥳 **Adds**

 - [x] Dockerfile 
 - [x] Docker Build workflow (publishes the image to dockerhub)

This is part part of the tribute-dao launcher: https://github.com/openlawteam/tribute-contracts/pull/390

In order to launch a DAO using docker-compose we need to dockerize the tribute-ui app. This PR adds the Dockerfile to build the docker image, and creates a minimal github workflow to publish a new image to Dockerhub on every push to the `main` branch. Later we can extend that to publish new images on every new release - if needed.