### PR TITLE
Simplifies ENS lookup for web3 modal account

### DIFF
--- a/src/components/web3/ConnectWalletModal.tsx
+++ b/src/components/web3/ConnectWalletModal.tsx
@@ -8,13 +8,12 @@ import {CHAINS} from '../../config';
 import {CopyWithTooltip} from '../common/CopyWithTooltip';
 import {CycleEllipsis} from '../feedback';
 import {StoreState} from '../../store/types';
-import {useENSName, useIsDefaultChain} from './hooks';
+import {useIsDefaultChain} from './hooks';
 import {useWeb3Modal} from './hooks';
 import {WalletIcon} from '.';
 import LoaderLarge from '../feedback/LoaderLarge';
 import Modal from '../common/Modal';
 import TimesSVG from '../../assets/svg/TimesSVG';
-import {normalizeString} from '../../util/helpers';
 
 type ConnectWalletModalProps = {
   modalProps: {
@@ -53,6 +52,7 @@ export default function ConnectWalletModal(
     // @todo Use and handle error in the UI
     // error,
     account,
+    accountENS,
     connected,
     connectWeb3Modal,
     disconnectWeb3Modal,
@@ -62,9 +62,6 @@ export default function ConnectWalletModal(
   } = useWeb3Modal();
 
   const {defaultChainError, isDefaultChain} = useIsDefaultChain();
-
-  const [ensReverseResolvedAddresses, setAddressesToENSReverseResolve] =
-    useENSName();
 
   /**
    * Their hooks
@@ -80,12 +77,6 @@ export default function ConnectWalletModal(
   const isWrongNetwork: boolean = isDefaultChain === false;
   const isChainGanache = networkId === CHAINS.GANACHE;
   const memberProfilePath: string = `/members/${connectedMemberAddress}`;
-  const [ensName] = ensReverseResolvedAddresses;
-
-  const ensNameFound: boolean =
-    account && normalizeString(ensName) !== normalizeString(account)
-      ? true
-      : false;
 
   const displayOptions: JSX.Element[] = Object.entries(providerOptions)
     // If mobile, filter-out `"injected"`
@@ -135,13 +126,6 @@ export default function ConnectWalletModal(
       setTimeout(onRequestClose, 0);
     }
   }, [isOpen, memberProfilePath, onRequestClose, pathname, previousPathname]);
-
-  // Set eth addresses to ENS reverse resolve
-  useEffect(() => {
-    if (!account) return;
-
-    setAddressesToENSReverseResolve([account]);
-  }, [account, setAddressesToENSReverseResolve]);
 
   /**
    * Functions
@@ -239,13 +223,13 @@ export default function ConnectWalletModal(
                   data-tip={
                     isCopied
                       ? 'copied!'
-                      : ensNameFound
-                      ? `${ensName} (${account})`
+                      : accountENS
+                      ? `${accountENS} (${account})`
                       : 'copy'
                   }
                   onClick={setCopied}
                   ref={elementRef}>
-                  {ensName || account}
+                  {accountENS || account}
                 </span>
               )}
               textToCopy={account}

--- a/src/components/web3/ConnectWalletModal.unit.test.tsx
+++ b/src/components/web3/ConnectWalletModal.unit.test.tsx
@@ -2,6 +2,7 @@ import {render, screen, waitFor} from '@testing-library/react';
 import {Store} from 'redux';
 import {useDispatch, useSelector} from 'react-redux';
 import userEvent from '@testing-library/user-event';
+import Web3 from 'web3';
 
 import {
   connectModalClose,
@@ -9,7 +10,7 @@ import {
   setConnectedMember,
 } from '../../store/actions';
 import {CHAINS} from '../../config';
-import {DEFAULT_ETH_ADDRESS} from '../../test/helpers';
+import {DEFAULT_ETH_ADDRESS, FakeHttpProvider} from '../../test/helpers';
 import {REVERSE_RECORDS_ADDRESS} from './helpers';
 import {StoreState} from '../../store/types';
 import {useEffect} from 'react';
@@ -104,13 +105,9 @@ describe('ConnectWalletModal unit tests', () => {
     render(
       <Wrapper
         useWallet
+        web3ModalContext={{accountENS: 'someone.eth'}}
         getProps={(p) => {
           store = p.store;
-
-          // Mock the `ReverseRecords.getNames` response
-          p.mockWeb3Provider.injectResult(
-            p.web3Instance.eth.abi.encodeParameter('string[]', ['someone.eth'])
-          );
         }}>
         <TestApp />
       </Wrapper>
@@ -214,6 +211,7 @@ describe('ConnectWalletModal unit tests', () => {
     const {getByText} = render(
       <Wrapper
         useWallet
+        web3ModalContext={{accountENS: 'someone.eth'}}
         getProps={(p) => {
           store = p.store;
 

--- a/src/components/web3/Web3ModalButton.tsx
+++ b/src/components/web3/Web3ModalButton.tsx
@@ -1,10 +1,9 @@
 import {isMobile} from '@walletconnect/browser-utils';
 import {useDispatch} from 'react-redux';
-import {useEffect} from 'react';
 
 import {connectModalOpen} from '../../store/actions';
-import {normalizeString, truncateEthAddress} from '../../util/helpers';
-import {useENSName, useIsDefaultChain} from './hooks';
+import {truncateEthAddress} from '../../util/helpers';
+import {useIsDefaultChain} from './hooks';
 import {useWeb3Modal} from './hooks';
 import {WalletIcon} from './';
 
@@ -28,11 +27,8 @@ export default function ConnectWalletButton({
    * Our hooks
    */
 
-  const {account, connected, web3Modal} = useWeb3Modal();
+  const {account, accountENS, connected, web3Modal} = useWeb3Modal();
   const {isDefaultChain} = useIsDefaultChain();
-
-  const [ensReverseResolvedAddresses, setAddressesToENSReverseResolve] =
-    useENSName();
 
   /**
    * Their hooks
@@ -44,24 +40,7 @@ export default function ConnectWalletButton({
    * Variables
    */
 
-  const [ensName] = ensReverseResolvedAddresses;
   const isWrongNetwork: boolean = isDefaultChain === false;
-
-  const ensNameFound: boolean =
-    account && normalizeString(ensName) !== normalizeString(account)
-      ? true
-      : false;
-
-  /**
-   * Effects
-   */
-
-  // Set eth addresses to ENS reverse resolve
-  useEffect(() => {
-    if (!account) return;
-
-    setAddressesToENSReverseResolve([account]);
-  }, [account, setAddressesToENSReverseResolve]);
 
   /**
    * Functions
@@ -75,7 +54,7 @@ export default function ConnectWalletButton({
     }
 
     if (account) {
-      return ensNameFound ? ensName : truncateEthAddress(account);
+      return accountENS || truncateEthAddress(account);
     }
 
     return 'Connect';

--- a/src/components/web3/Web3ModalButton.unit.test.tsx
+++ b/src/components/web3/Web3ModalButton.unit.test.tsx
@@ -57,6 +57,7 @@ describe('Web3ModalButton unit tests', () => {
           );
         }}
         web3ModalContext={{
+          accountENS: 'someone.eth',
           web3Modal: {cachedProvider: 'injected'} as Core,
         }}>
         <Web3ModalButton />

--- a/src/components/web3/Web3ModalManager.tsx
+++ b/src/components/web3/Web3ModalManager.tsx
@@ -8,6 +8,8 @@ import useWeb3ModalManager, {
 } from './hooks/useWeb3ModalManager';
 import {AsyncStatus} from '../../util/types';
 import {ETHEREUM_PROVIDER_URL} from '../../config';
+import {normalizeString} from '../../util/helpers';
+import {useENSName} from './hooks';
 
 type Web3ModalProviderArguments = {
   defaultChain?: number;
@@ -33,6 +35,7 @@ type Web3ModalManagerProps = {
 
 export type Web3ModalContextValue = {
   account: string | undefined;
+  accountENS?: string;
   connected: boolean | undefined;
   connectWeb3Modal: (providerName: string) => void;
   disconnectWeb3Modal: () => void;
@@ -119,6 +122,20 @@ export default function Web3ModalManager({
     web3Modal,
   } = useWeb3ModalManager(web3ModalProviderArguments);
 
+  const [ensReverseResolvedAddresses, setAddressesToENSReverseResolve] =
+    useENSName(web3Instance);
+
+  /**
+   * Variables
+   */
+
+  const [ensName] = ensReverseResolvedAddresses;
+
+  const accountENS: string | undefined =
+    ensName && normalizeString(ensName) !== normalizeString(account)
+      ? ensName
+      : undefined;
+
   /**
    * Effects
    */
@@ -136,12 +153,20 @@ export default function Web3ModalManager({
     }
   }, [connected, initialCachedConnectorCheckStatus]);
 
+  // Set eth addresses to ENS reverse resolve
+  useEffect(() => {
+    if (!account) return;
+
+    setAddressesToENSReverseResolve([account]);
+  }, [account, setAddressesToENSReverseResolve]);
+
   /**
    * Render
    */
 
   const web3ModalContext: Web3ModalContextValue = {
     account,
+    accountENS,
     connected,
     connectWeb3Modal,
     disconnectWeb3Modal,

--- a/src/components/web3/hooks/useENSName.ts
+++ b/src/components/web3/hooks/useENSName.ts
@@ -36,6 +36,7 @@ export function useENSName(
 
   useEffect(() => {
     if (!web3Instance || !addresses.length) return;
+
     handleGetENSNamesCached(addresses, web3Instance);
   }, [addresses, handleGetENSNamesCached, web3Instance]);
 

--- a/src/components/web3/hooks/useENSName.ts
+++ b/src/components/web3/hooks/useENSName.ts
@@ -2,12 +2,18 @@ import {useCallback, useEffect, useState} from 'react';
 import Web3 from 'web3';
 
 import {reverseResolveENS} from '../helpers';
-import {useWeb3Modal} from '.';
 
-export function useENSName(): [
-  state: string[],
-  setState: (a: string[]) => void
-] {
+/**
+ * A hook to reverse resolve ENS addresses by setting
+ * the addresses, using the returned callback, and then receving
+ * the response.
+ *
+ * @param web3Instance `Web3`
+ * @returns `[state: string[], setState: (a: string[]) => void]`
+ */
+export function useENSName(
+  web3Instance: Web3 | undefined
+): [state: string[], setState: (a: string[]) => void] {
   /**
    * State
    */
@@ -17,12 +23,6 @@ export function useENSName(): [
   const [reverseResolvedAddresses, setReverseResolvedAddresses] = useState<
     string[]
   >([]);
-
-  /**
-   * Our hooks
-   */
-
-  const {web3Instance} = useWeb3Modal();
 
   /**
    * Cached callbacks
@@ -36,7 +36,6 @@ export function useENSName(): [
 
   useEffect(() => {
     if (!web3Instance || !addresses.length) return;
-
     handleGetENSNamesCached(addresses, web3Instance);
   }, [addresses, handleGetENSNamesCached, web3Instance]);
 

--- a/src/components/web3/hooks/useENSName.unit.test.ts
+++ b/src/components/web3/hooks/useENSName.unit.test.ts
@@ -16,7 +16,7 @@ describe('useENSName unit tests', () => {
 
     await act(async () => {
       const {result, waitForValueToChange} = await renderHook(
-        () => useENSName(),
+        () => useENSName(web3Instance),
         {
           wrapper: Wrapper,
           initialProps: {
@@ -64,7 +64,7 @@ describe('useENSName unit tests', () => {
 
     await act(async () => {
       const {result, waitForValueToChange} = await renderHook(
-        () => useENSName(),
+        () => useENSName(web3Instance),
         {
           wrapper: Wrapper,
           initialProps: {

--- a/src/pages/members/hooks/useMembers.ts
+++ b/src/pages/members/hooks/useMembers.ts
@@ -48,7 +48,7 @@ export default function useMembers(): UseMembersReturn {
   const {web3Instance} = useWeb3Modal();
 
   const [ensReverseResolvedAddresses, setAddressesToENSReverseResolve] =
-    useENSName();
+    useENSName(web3Instance);
 
   /**
    * GQL Query


### PR DESCRIPTION

✨ **Updates**

 - Adds ENS reverse lookup to `Web3ModalContext` so it's not called each time the modal is displayed, or the menu is opened.
