### PR TITLE
Adds units to member listing cards

### DIFF
--- a/src/assets/scss/_membercard.scss
+++ b/src/assets/scss/_membercard.scss
@@ -2,11 +2,13 @@
 @use "./mixins" as *; /* load without namespace for convenience */
 
 .membercard {
+  align-items: center;
   background-color: $color-background-primary;
   border-radius: 15px;
+  box-shadow: 0 2px 2px 0 $color-shadow-primary;
+  display: flex;
   padding: 2rem;
   position: relative;
-  box-shadow: 0 2px 2px 0 $color-shadow-primary;
 
   &:hover {
     cursor: pointer;
@@ -36,4 +38,18 @@
   &:last-child {
     margin: 0;
   }
+}
+
+.membercard__units {
+  @include fluid-type(
+    $bp-sm,
+    $bp-xl,
+    16px,
+    20px
+  ); /* min font-size 1rem, max 1.25rem */
+  background: $color-shadow-primary;
+  border-radius: 0.25em;
+  font-family: $font-accent;
+  margin-left: 0.25em;
+  padding: 0 0.33em;
 }

--- a/src/pages/members/MemberCard.tsx
+++ b/src/pages/members/MemberCard.tsx
@@ -1,8 +1,8 @@
 import {Link} from 'react-router-dom';
 import {v4 as uuidv4} from 'uuid';
 
+import {formatNumber, normalizeString} from '../../util/helpers';
 import {Member} from './types';
-import {normalizeString} from '../../util/helpers';
 import {useRef} from 'react';
 import {useWeb3Modal} from '../../components/web3/hooks';
 import ReactTooltip from 'react-tooltip';
@@ -13,6 +13,7 @@ type MemberCardProps = {
 };
 
 const DEFAULT_CARD_LINK: string = '#';
+const TOOLTIP_DELAY: number = 200;
 
 /**
  * Shows a preview of a member's profile
@@ -33,11 +34,15 @@ export default function MemberCard(props: MemberCardProps): JSX.Element {
    * Refs
    */
 
-  const tooltipIDRef = useRef<string>(uuidv4());
+  const titleTooltipIDRef = useRef<string>(uuidv4());
+  const unitsTooltipIDRef = useRef<string>(uuidv4());
 
   /**
    * Variables
    */
+
+  const {units} = member;
+  const unitsFormatted: string = formatNumber(units);
 
   const ensNameFound: boolean =
     member?.addressENS &&
@@ -61,7 +66,7 @@ export default function MemberCard(props: MemberCardProps): JSX.Element {
         {/* TITLE */}
         <h3
           className="membercard__title"
-          data-for={tooltipIDRef.current}
+          data-for={titleTooltipIDRef.current}
           data-tip={
             ensNameFound
               ? `${member.addressENS} (${member.address})`
@@ -71,9 +76,23 @@ export default function MemberCard(props: MemberCardProps): JSX.Element {
         </h3>
 
         <ReactTooltip
-          delayShow={200}
+          delayShow={TOOLTIP_DELAY}
           effect="solid"
-          id={tooltipIDRef.current}
+          id={titleTooltipIDRef.current}
+        />
+
+        {/* UNITS */}
+        <span
+          className="membercard__units"
+          data-for={unitsTooltipIDRef.current}
+          data-tip={`${unitsFormatted} unit${Number(units) === 1 ? '' : 's'}`}>
+          {unitsFormatted}
+        </span>
+
+        <ReactTooltip
+          delayShow={TOOLTIP_DELAY}
+          effect="solid"
+          id={unitsTooltipIDRef.current}
         />
       </div>
     </Link>

--- a/src/pages/members/MemberCard.unit.test.tsx
+++ b/src/pages/members/MemberCard.unit.test.tsx
@@ -25,6 +25,16 @@ describe('MemberCard unit tests', () => {
     expect(getByText(DEFAULT_ETH_ADDRESS)).toBeInTheDocument();
   });
 
+  test('should render with units', () => {
+    const {getByText} = render(
+      <Wrapper>
+        <MemberCard member={DEFAULT_MEMBER} />
+      </Wrapper>
+    );
+
+    expect(getByText('100,000')).toBeInTheDocument();
+  });
+
   test('should render with member ens address', () => {
     const {getByText} = render(
       <Wrapper>
@@ -42,7 +52,9 @@ describe('MemberCard unit tests', () => {
       </Wrapper>
     );
 
-    expect(getByRole('link', {name: DEFAULT_ETH_ADDRESS})).toBeInTheDocument();
+    expect(
+      getByRole('link', {name: `${DEFAULT_ETH_ADDRESS} 100,000`})
+    ).toBeInTheDocument();
   });
 
   test('should render tooltip with member address', async () => {
@@ -55,6 +67,18 @@ describe('MemberCard unit tests', () => {
     userEvent.hover(getByText(DEFAULT_ETH_ADDRESS));
 
     expect(getAllByText(DEFAULT_ETH_ADDRESS).length === 2).toBe(true);
+  });
+
+  test('should render tooltip with member units', async () => {
+    const {getByText} = render(
+      <Wrapper>
+        <MemberCard member={DEFAULT_MEMBER} />
+      </Wrapper>
+    );
+
+    userEvent.hover(getByText('100,000'));
+
+    expect(getByText(/100,000 units/i)).toBeInTheDocument();
   });
 
   test('should render tooltip with member ens address', async () => {

--- a/src/pages/members/MemberCard.unit.test.tsx
+++ b/src/pages/members/MemberCard.unit.test.tsx
@@ -70,15 +70,41 @@ describe('MemberCard unit tests', () => {
   });
 
   test('should render tooltip with member units', async () => {
-    const {getByText} = render(
+    // Assert >1 units
+
+    const {getByText, rerender} = render(
       <Wrapper>
         <MemberCard member={DEFAULT_MEMBER} />
       </Wrapper>
     );
 
-    userEvent.hover(getByText('100,000'));
+    userEvent.hover(getByText(/^100,000$/));
 
-    expect(getByText(/100,000 units/i)).toBeInTheDocument();
+    expect(getByText(/^100,000 units$/i)).toBeInTheDocument();
+
+    // Assert 0 units
+
+    rerender(
+      <Wrapper>
+        <MemberCard member={{...DEFAULT_MEMBER, units: '0'}} />
+      </Wrapper>
+    );
+
+    userEvent.hover(getByText(/^0$/));
+
+    expect(getByText(/^0 units$/i)).toBeInTheDocument();
+
+    // Assert 1 unit
+
+    rerender(
+      <Wrapper>
+        <MemberCard member={{...DEFAULT_MEMBER, units: '1'}} />
+      </Wrapper>
+    );
+
+    userEvent.hover(getByText(/^1$/));
+
+    expect(getByText(/^1 unit$/i)).toBeInTheDocument();
   });
 
   test('should render tooltip with member ens address', async () => {

--- a/src/util/helpers/formatNumber.ts
+++ b/src/util/helpers/formatNumber.ts
@@ -3,14 +3,18 @@
  *
  * Formats a number (U.S. region) with commas (e.g. 1000 -> 1,000).
  *
+ * If an error occurs while converting to a `Number` the original value
+ * is attempted to be converted to a `string` and returned.
+ *
  * @param {string | number} value
  * @returns {string}
- *
- * @todo maybe a more friendly way via Intl API in JS core?
  */
 export const formatNumber = (value: number | string): string => {
-  const regEx = new RegExp(/(\d)(?=(\d{3})+(?:\.\d+)?$)/g);
-  return typeof value === 'number'
-    ? value.toString().replace(/,/g, '').replace(regEx, '$1,')
-    : value.replace(/,/g, '').replace(regEx, '$1,');
+  const number: number = Number(value ?? undefined);
+
+  if (isNaN(number)) {
+    return '';
+  }
+
+  return number.toLocaleString('en-US');
 };

--- a/src/util/helpers/formatNumber.unit.test.ts
+++ b/src/util/helpers/formatNumber.unit.test.ts
@@ -1,0 +1,25 @@
+import {formatNumber} from '.';
+
+describe('formatNumber unit tests', () => {
+  test('should return en-US locale, comma-separated `String`', () => {
+    // Assert number->string
+    expect(formatNumber(0)).toBe('0');
+    expect(formatNumber(10)).toBe('10');
+    expect(formatNumber(100)).toBe('100');
+    expect(formatNumber(1000)).toBe('1,000');
+    expect(formatNumber(10000000000)).toBe('10,000,000,000');
+
+    // Assert string->string
+    expect(formatNumber('0')).toBe('0');
+    expect(formatNumber('10')).toBe('10');
+    expect(formatNumber('100')).toBe('100');
+    expect(formatNumber('1000')).toBe('1,000');
+    expect(formatNumber('10000000000')).toBe('10,000,000,000');
+  });
+
+  test('if NaN, should return empty `String`', () => {
+    // Assert number->string
+    expect(formatNumber(undefined as any)).toBe('');
+    expect(formatNumber(null as any)).toBe('');
+  });
+});


### PR DESCRIPTION
Adds the number of units a member owns to the member listing cards.

✨ **Updates**

 - `MemberCard` shows number of units
 - `MemberCard` has tooltip when hovering over number of units to show text `"<number> units"`.
 - `formatNumber` implementation updated to use `toLocaleString`