### PR TITLE
Member card cleanup

### DIFF
--- a/src/assets/scss/_membercard.scss
+++ b/src/assets/scss/_membercard.scss
@@ -2,14 +2,10 @@
 @use "./mixins" as *; /* load without namespace for convenience */
 
 .membercard {
-  align-items: center;
   background-color: $color-background-primary;
   border-radius: 15px;
   box-shadow: 0 2px 2px 0 $color-shadow-primary;
-  display: flex;
   padding: 2rem;
-  position: relative;
-  justify-content: space-between;
 
   &:hover {
     cursor: pointer;
@@ -18,6 +14,12 @@
   &--connected-account {
     box-shadow: 0 2px 2px 0 $color-primary-hover;
   }
+}
+
+.membercard__row {
+  align-items: center;
+  display: flex;
+  justify-content: space-between;
 }
 
 .membercard__link {
@@ -32,9 +34,10 @@
     20px
   ); /* min font-size 1rem, max 1.25rem */
   @include text-truncate;
-  line-height: 1.6;
-  text-align: center;
   font-weight: normal;
+  line-height: 1.6;
+  margin: 0;
+  text-align: center;
 
   &:last-child {
     margin: 0;
@@ -53,4 +56,21 @@
   font-family: $font-accent;
   margin-left: 0.25em;
   padding: 0 0.33em;
+}
+
+.membercard__ens {
+  @include fluid-type(
+    $bp-sm,
+    $bp-xl,
+    16px,
+    18px
+  ); /* min font-size 1rem, max 1.125rem */
+  @include text-truncate;
+  font-weight: normal;
+  margin-top: 0.5 em;
+  text-align: center;
+
+  &:last-child {
+    margin: 0;
+  }
 }

--- a/src/pages/members/MemberCard.tsx
+++ b/src/pages/members/MemberCard.tsx
@@ -1,7 +1,11 @@
 import {Link} from 'react-router-dom';
 import {v4 as uuidv4} from 'uuid';
 
-import {formatNumber, normalizeString} from '../../util/helpers';
+import {
+  formatNumber,
+  formatNumberAbbreviated,
+  normalizeString,
+} from '../../util/helpers';
 import {Member} from './types';
 import {useRef} from 'react';
 import {useWeb3Modal} from '../../components/web3/hooks';
@@ -43,6 +47,7 @@ export default function MemberCard(props: MemberCardProps): JSX.Element {
    */
 
   const {units} = member;
+  const unitAbbreviated: string = formatNumberAbbreviated(Number(units));
   const unitsFormatted: string = formatNumber(units);
 
   const ensNameFound: boolean =
@@ -91,7 +96,7 @@ export default function MemberCard(props: MemberCardProps): JSX.Element {
             data-tip={`${unitsFormatted} unit${
               Number(units) === 1 ? '' : 's'
             }`}>
-            {unitsFormatted}
+            {unitAbbreviated}
           </span>
 
           <ReactTooltip

--- a/src/pages/members/MemberCard.tsx
+++ b/src/pages/members/MemberCard.tsx
@@ -34,6 +34,7 @@ export default function MemberCard(props: MemberCardProps): JSX.Element {
    * Refs
    */
 
+  const ensTooltipIDRef = useRef<string>(uuidv4());
   const titleTooltipIDRef = useRef<string>(uuidv4());
   const unitsTooltipIDRef = useRef<string>(uuidv4());
 
@@ -50,6 +51,10 @@ export default function MemberCard(props: MemberCardProps): JSX.Element {
       ? true
       : false;
 
+  const addressTooltipText: string = ensNameFound
+    ? `${member.addressENS} (${member.address})`
+    : member.address;
+
   /**
    * Render
    */
@@ -63,37 +68,57 @@ export default function MemberCard(props: MemberCardProps): JSX.Element {
             ? `membercard--connected-account`
             : ''
         }`}>
-        {/* TITLE */}
-        <h3
-          className="membercard__title"
-          data-for={titleTooltipIDRef.current}
-          data-tip={
-            ensNameFound
-              ? `${member.addressENS} (${member.address})`
-              : member.address
-          }>
-          {member?.addressENS || member.address}
-        </h3>
+        {/* ROW 1 */}
+        <div className="membercard__row">
+          {/* TITLE */}
+          <h3
+            className="membercard__title"
+            data-for={titleTooltipIDRef.current}
+            data-tip={addressTooltipText}>
+            {member.address}
+          </h3>
 
-        <ReactTooltip
-          delayShow={TOOLTIP_DELAY}
-          effect="solid"
-          id={titleTooltipIDRef.current}
-        />
+          <ReactTooltip
+            delayShow={TOOLTIP_DELAY}
+            effect="solid"
+            id={titleTooltipIDRef.current}
+          />
 
-        {/* UNITS */}
-        <span
-          className="membercard__units"
-          data-for={unitsTooltipIDRef.current}
-          data-tip={`${unitsFormatted} unit${Number(units) === 1 ? '' : 's'}`}>
-          {unitsFormatted}
-        </span>
+          {/* UNITS */}
+          <span
+            className="membercard__units"
+            data-for={unitsTooltipIDRef.current}
+            data-tip={`${unitsFormatted} unit${
+              Number(units) === 1 ? '' : 's'
+            }`}>
+            {unitsFormatted}
+          </span>
 
-        <ReactTooltip
-          delayShow={TOOLTIP_DELAY}
-          effect="solid"
-          id={unitsTooltipIDRef.current}
-        />
+          <ReactTooltip
+            delayShow={TOOLTIP_DELAY}
+            effect="solid"
+            id={unitsTooltipIDRef.current}
+          />
+        </div>
+
+        {/* ROW 2 */}
+        {ensNameFound && member?.addressENS && (
+          <div className="membercard__row">
+            {/* ENS */}
+            <span
+              className="membercard__ens"
+              data-for={ensTooltipIDRef.current}
+              data-tip={addressTooltipText}>
+              {member?.addressENS}
+            </span>
+
+            <ReactTooltip
+              delayShow={TOOLTIP_DELAY}
+              effect="solid"
+              id={ensTooltipIDRef.current}
+            />
+          </div>
+        )}
       </div>
     </Link>
   );

--- a/src/pages/members/MemberCard.unit.test.tsx
+++ b/src/pages/members/MemberCard.unit.test.tsx
@@ -1,11 +1,11 @@
-import {render, waitFor} from '@testing-library/react';
+import {render} from '@testing-library/react';
 
 import {BURN_ADDRESS} from '../../util/constants';
 import {DEFAULT_ETH_ADDRESS} from '../../test/helpers';
 import {Member} from './types';
 import MemberCard from './MemberCard';
-import Wrapper from '../../test/Wrapper';
 import userEvent from '@testing-library/user-event';
+import Wrapper from '../../test/Wrapper';
 
 describe('MemberCard unit tests', () => {
   const DEFAULT_MEMBER: Member = {
@@ -42,7 +42,8 @@ describe('MemberCard unit tests', () => {
       </Wrapper>
     );
 
-    expect(getByText(/cool.eth/i)).toBeInTheDocument();
+    expect(getByText(DEFAULT_ETH_ADDRESS)).toBeInTheDocument();
+    expect(getByText(/cool\.eth/i)).toBeInTheDocument();
   });
 
   test('should render with link', () => {
@@ -107,7 +108,19 @@ describe('MemberCard unit tests', () => {
     expect(getByText(/^1 unit$/i)).toBeInTheDocument();
   });
 
-  test('should render tooltip with member ens address', async () => {
+  test('should render tooltip with member ens address on eth address hover', async () => {
+    const {getByText} = render(
+      <Wrapper>
+        <MemberCard member={{...DEFAULT_MEMBER, addressENS: 'cool.eth'}} />
+      </Wrapper>
+    );
+
+    userEvent.hover(getByText(DEFAULT_ETH_ADDRESS));
+
+    expect(getByText(`cool.eth (${DEFAULT_ETH_ADDRESS})`)).toBeInTheDocument();
+  });
+
+  test('should render tooltip with member ens address on ens name hover', async () => {
     const {getByText} = render(
       <Wrapper>
         <MemberCard member={{...DEFAULT_MEMBER, addressENS: 'cool.eth'}} />

--- a/src/pages/members/MemberCard.unit.test.tsx
+++ b/src/pages/members/MemberCard.unit.test.tsx
@@ -32,7 +32,7 @@ describe('MemberCard unit tests', () => {
       </Wrapper>
     );
 
-    expect(getByText('100,000')).toBeInTheDocument();
+    expect(getByText('100k')).toBeInTheDocument();
   });
 
   test('should render with member ens address', () => {
@@ -54,7 +54,7 @@ describe('MemberCard unit tests', () => {
     );
 
     expect(
-      getByRole('link', {name: `${DEFAULT_ETH_ADDRESS} 100,000`})
+      getByRole('link', {name: `${DEFAULT_ETH_ADDRESS} 100k`})
     ).toBeInTheDocument();
   });
 
@@ -79,7 +79,7 @@ describe('MemberCard unit tests', () => {
       </Wrapper>
     );
 
-    userEvent.hover(getByText(/^100,000$/));
+    userEvent.hover(getByText(/^100k$/));
 
     expect(getByText(/^100,000 units$/i)).toBeInTheDocument();
 

--- a/src/util/helpers/formatNumberAbbreviated.ts
+++ b/src/util/helpers/formatNumberAbbreviated.ts
@@ -1,0 +1,31 @@
+/**
+ * formatNumberAbbreviated
+ *
+ * Formats a `number` to abbreviated `string` for display.
+ *
+ * Has better browser support than using the newer options in `Intl.NumberFormat`.
+ *
+ * e.g. 1000000 likes->1M likes
+ *
+ * @param value `number`
+ * @returns `string`
+ *
+ * @see https://stackoverflow.com/questions/25611937/abbreviate-a-localized-number-in-javascript-for-thousands-1k-and-millions-1m
+ * @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/NumberFormat/NumberFormat#scientific_engineering_or_compact_notations
+ */
+export function formatNumberAbbreviated(value: number): string {
+  const intlFormat = (v: number): string =>
+    new Intl.NumberFormat().format(Math.round(v * 10) / 10);
+
+  // Trillions
+  if (value >= 1000000000000) return intlFormat(value / 1000000000000) + 'T';
+  // Billions
+  if (value >= 1000000000) return intlFormat(value / 1000000000) + 'B';
+  // Millions
+  if (value >= 1000000) return intlFormat(value / 1000000) + 'M';
+  // Thousands
+  if (value >= 1000) return intlFormat(value / 1000) + 'k';
+
+  // Fallthrough
+  return intlFormat(value);
+}

--- a/src/util/helpers/formatNumberAbbreviated.unit.test.ts
+++ b/src/util/helpers/formatNumberAbbreviated.unit.test.ts
@@ -1,0 +1,23 @@
+import {formatNumberAbbreviated} from '.';
+
+describe('formatNumberAbbreviated', () => {
+  test('should return correct number abbreviations', () => {
+    expect(formatNumberAbbreviated(0)).toBe('0');
+    expect(formatNumberAbbreviated(1)).toBe('1');
+    expect(formatNumberAbbreviated(10)).toBe('10');
+    expect(formatNumberAbbreviated(100)).toBe('100');
+    expect(formatNumberAbbreviated(1000)).toBe('1k');
+    expect(formatNumberAbbreviated(10000)).toBe('10k');
+    expect(formatNumberAbbreviated(100000)).toBe('100k');
+    expect(formatNumberAbbreviated(1000000)).toBe('1M');
+    expect(formatNumberAbbreviated(10000000)).toBe('10M');
+    expect(formatNumberAbbreviated(100000000)).toBe('100M');
+    expect(formatNumberAbbreviated(1000000000)).toBe('1B');
+    expect(formatNumberAbbreviated(10000000000)).toBe('10B');
+    expect(formatNumberAbbreviated(100000000000)).toBe('100B');
+    expect(formatNumberAbbreviated(1000000000000)).toBe('1T');
+    expect(formatNumberAbbreviated(10000000000000)).toBe('10T');
+    expect(formatNumberAbbreviated(100000000000000)).toBe('100T');
+    expect(formatNumberAbbreviated(1000000000000000)).toBe('1,000T');
+  });
+});

--- a/src/util/helpers/index.ts
+++ b/src/util/helpers/index.ts
@@ -3,6 +3,7 @@ export * from './disableReactDevTools';
 export * from './dontCloseWindowWarning';
 export * from './formatDecimal';
 export * from './formatNumber';
+export * from './formatNumberAbbreviated';
 export * from './getTimeRemaining';
 export * from './getValidationError';
 export * from './isPossibleContractWallet';


### PR DESCRIPTION
Fixes #508 



✨ **Updates**

 - Shows both Ethereum address and ens address, if available, on member card.
 - Units are abbreviated (i.e. `100,000` -> `100k`)
 - Cards are now slimmer, fitting more on the page
 

