### PR TITLE
Disable adapter/extension manager feature

### DIFF
--- a/src/Routes.tsx
+++ b/src/Routes.tsx
@@ -1,7 +1,7 @@
 import {Route, Switch} from 'react-router-dom';
 
 import {ENABLE_KYC_ONBOARDING} from './config';
-import AdapterOrExtensionManager from './components/adapters-extensions/AdapterOrExtensionManager';
+// import AdapterOrExtensionManager from './components/adapters-extensions/AdapterOrExtensionManager';
 import CreateGovernanceProposal from './pages/governance/CreateGovernanceProposal';
 import CreateOnboardingProposal from './pages/onboarding/CreateOnboardingProposal';
 import CreateTransferProposal from './pages/transfers/CreateTransferProposal';
@@ -122,12 +122,14 @@ export default function Routes() {
           path="/members/:ethereumAddress"
           render={() => <MemberProfile />}
         />,
-        <Route
-          key="dao-manager"
-          exact
-          path="/dao-manager"
-          render={() => <AdapterOrExtensionManager />}
-        />,
+        // @note Disabling DAO Manager for now because we paused on maintaining
+        // it.
+        // <Route
+        //   key="dao-manager"
+        //   exact
+        //   path="/dao-manager"
+        //   render={() => <AdapterOrExtensionManager />}
+        // />,
         <Route key="redeem" exact path="/redeem" render={() => <Redeem />} />,
         // 404 component (note: does not redirect to a route to maintain original path)
         <Route key="no-match" component={NotFound} />,

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -241,7 +241,7 @@ export function NavHamburger() {
                     </li>
                   )}
                   {/* The Manage DAO link is available to both connected member users and connected delegate users. */}
-                  {/* @note Hiding DAO Manager for now because we paused on maintaining it. */}
+                  {/* @note Disabling DAO Manager for now because we paused on maintaining it. */}
                   {/* {isCurrentMemberOrDelegateConnected && (
                     <li
                       onClick={() => {


### PR DESCRIPTION
✨ **Updates**

 - Disable `dao-manager` route (adapter/extension manager feature) for now because we paused on maintaining it. (We have already hidden the nav link for it.)