### PR TITLE
Add back warn for missing Alchemy API key

### DIFF
--- a/src/util/helpers/getAlchemyURL.ts
+++ b/src/util/helpers/getAlchemyURL.ts
@@ -19,6 +19,8 @@ export function getAlchemyURL(
   networkID: typeof CHAINS[keyof typeof CHAINS] = DEFAULT_CHAIN
 ): AlchemyAPIURL | undefined {
   if (!process.env.REACT_APP_ALCHEMY_API_KEY) {
+    console.warn('No Alchemy API key was found.');
+
     return;
   }
 


### PR DESCRIPTION
🥳 **Adds**

 - Add console warn for missing Alchemy API key (it was recently removed)
